### PR TITLE
docs: update schemaui version and cli installation instructions

### DIFF
--- a/.github/workflows/release-plz-release.yml
+++ b/.github/workflows/release-plz-release.yml
@@ -42,9 +42,40 @@ jobs:
           permission-pull-requests: read
 
       - name: Run release-plz release
+        id: release_step
         uses: release-plz/action@v0.5
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Sync README versions
+        id: sync_readme
+        env:
+          PACKAGE_NAME: ${{ steps.release_step.outputs.package_name }}
+          RELEASE_VERSION: ${{ steps.release_step.outputs.version }}
+        if: ${{ steps.release_step.outputs.version != '' }}
+        run: |
+          echo "Package name: $PACKAGE_NAME"
+          echo "Release version: $RELEASE_VERSION"
+
+          if [ "$PACKAGE_NAME" != "schemaui" ]; then
+            echo "Skipping README sync because package is $PACKAGE_NAME (not schemaui)"
+            exit 0
+          fi
+
+          echo "Syncing README versions to $RELEASE_VERSION"
+          sed -i "s/schemaui = \"[0-9]\+\.[0-9]\+\.[0-9]\+\"/schemaui = \"$RELEASE_VERSION\"/" README.md
+          sed -i "s/schemaui = \"[0-9]\+\.[0-9]\+\.[0-9]\+\"/schemaui = \"$RELEASE_VERSION\"/" README.ZH.md
+
+          git config user.name "github‑actions[bot]"
+          git config user.email "41898282+github‑actions[bot]@users.noreply.github.com"
+
+          git add README.md README.ZH.md
+          if git diff --cached --quiet; then
+            echo "No README changes detected, skipping commit."
+          else
+            git commit -m "chore: sync version to $RELEASE_VERSION in README files"
+            git push
+          fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,4 +69,5 @@ strip = "debuginfo"
 [package.metadata.release]
 pre-release-replacements = [
     { file = "README.md", search = "schemaui = \"[0-9]+\\.[0-9]+\\.[0-9]+[^\"]*\"", replace = "schemaui = \"{{version}}\"" },
+    { file = "README.ZH.md", search = "schemaui = \"[0-9]+\\.[0-9]+\\.[0-9]+[^\"]*\"", replace = "schemaui = \"{{version}}\"" },
 ]

--- a/README.ZH.md
+++ b/README.ZH.md
@@ -36,7 +36,7 @@
 
 ```toml
 [dependencies]
-schemaui = "0.1.1"
+schemaui = "0.3.1"
 serde_json = "1"
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ see the full list of issues before saving.
 
 ```toml
 [dependencies]
-schemaui = "0.2.0"
+schemaui = "0.3.1"
 serde_json = "1"
 ```
 

--- a/docs/en/cli_usage.md
+++ b/docs/en/cli_usage.md
@@ -16,7 +16,7 @@ cargo run -p schemaui-cli -- --schema ./schema.json --config ./config.yaml
 ### Install as a binary
 
 ```bash
-cargo install --path schemaui-cli --locked
+cargo install schemaui-cli
 schemaui --help             # binary is named `schemaui` via the clap metadata
 ```
 

--- a/docs/zh/cli_usage.zh.md
+++ b/docs/zh/cli_usage.zh.md
@@ -15,7 +15,7 @@ cargo run -p schemaui-cli -- --schema ./schema.json --config ./config.yaml
 ### 安装为二进制文件
 
 ```bash
-cargo install --path schemaui-cli --locked
+cargo install schemaui-cli
 schemaui --help             # 二进制文件通过 clap 元数据命名为 `schemaui`
 ```
 


### PR DESCRIPTION
- Update schemaui dependency version from 0.1 to 0.3.1 in README.ZH.md
- Update schemaui dependency version from 0.2.0 to 0.3.1 in README.md
- Add README.ZH.md to pre-release replacements in Cargo.toml
- Simplify cargo install command in both English and Chinese CLI usage docs by removing --path and --locked flags