### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.1...schemaui-cli-v0.2.2) - 2025-11-16
+
+### Added
+
+- *(web)* add embedded web UI with `web` feature and CLI subcommand
+
+### Fixed
+
+- *(version)* trigger the release ci/cd.
+
+### Other
+
+- release
+- *(ui)* refactor string literals to double quotes and remove save-and-exit feature
+- update schemaui version and cli installation instructions
+
+## [0.3.2](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.3.1...schemaui-v0.3.2) - 2025-11-16
+
+### Fixed
+
+- *(gitignore)* exclude node_modules directories recursively
+
 ## [0.3.1](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.3.0...schemaui-v0.3.1) - 2025-11-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "schemaui"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "schemaui-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["schemaui-cli"]
 [package]
 name = "schemaui"
 authors = ["unic <yuniqueunic@gmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 keywords = ["tui", "schema", "configuration", "terminal", "cross-platform"]
 categories = ["command-line-interface", "config"]

--- a/schemaui-cli/Cargo.toml
+++ b/schemaui-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schemaui-cli"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 authors = ["unic <yuniqueunic@gmail.com>"]
 description = "CLI wrapper for schemaui, rendering JSON Schemas as TUIs"


### PR DESCRIPTION



## 🤖 New release

* `schemaui`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `schemaui-cli`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `schemaui`

<blockquote>

## [0.3.2](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.3.1...schemaui-v0.3.2) - 2025-11-16

### Fixed

- *(gitignore)* exclude node_modules directories recursively
</blockquote>

## `schemaui-cli`

<blockquote>

## [0.2.2](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.1...schemaui-cli-v0.2.2) - 2025-11-16

### Added

- *(web)* add embedded web UI with `web` feature and CLI subcommand

### Fixed

- *(version)* trigger the release ci/cd.

### Other

- release
- *(ui)* refactor string literals to double quotes and remove save-and-exit feature
- update schemaui version and cli installation instructions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).