### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.3...schemaui-cli-v0.2.4) - 2025-11-23
+
+### Other
+
+- updated the following local packages: schemaui
+
 ## [0.2.2](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.1...schemaui-cli-v0.2.2) - 2025-11-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "schemaui"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "schemaui-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["schemaui-cli"]
 [package]
 name = "schemaui"
 authors = ["unic <yuniqueunic@gmail.com>"]
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 keywords = ["tui", "schema", "configuration", "terminal", "cross-platform"]
 categories = ["command-line-interface", "config"]

--- a/schemaui-cli/Cargo.toml
+++ b/schemaui-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schemaui-cli"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 authors = ["unic <yuniqueunic@gmail.com>"]
 description = "CLI wrapper for schemaui, rendering JSON Schemas as TUIs"
@@ -15,7 +15,7 @@ name = "schemaui"
 path = "src/main.rs"
 
 [dependencies]
-schemaui = { path = "..", version = "0.3.3" }
+schemaui = { path = "..", version = "0.4.0" }
 serde_json = "1"
 color-eyre = "0.6"
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `schemaui`: 0.3.3 -> 0.4.0 (⚠ API breaking changes)
* `schemaui-cli`: 0.2.3 -> 0.2.4

### ⚠ `schemaui` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_missing.ron

Failed in:
  function schemaui::ui_ast::form_schema::form_schema_from_ui_ast, previously in file /tmp/.tmpu4ajBS/schemaui/src/ui_ast/form_schema.rs:11

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/module_missing.ron

Failed in:
  mod schemaui::ui_ast::form_schema, previously in file /tmp/.tmpu4ajBS/schemaui/src/ui_ast/form_schema.rs:1
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `schemaui`

<blockquote>

## [0.4.0](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.3.3...schemaui-v0.4.0) - 2025-11-23

### Added

- *(tui)* add help overlay with keyboard shortcuts and validation errors, rename ui to backend in demo
- *(ui)* add variant selector popup for composite list entries with multiple variants

### Fixed

- *(tui)* prevent auto-creating new entry when deleting last item from composite list in overlay
- *(tui)* refactor focus navigation logic in form state
- *(tests)* enhance route schema and remove outdated overlay tests
- *(composite)* change anyOf behavior to return single value instead of array

### Other

- *(web)* improve array field editing with overlay support and fix composite list rendering
- *(deps)* upgrade jsonschema from 0.33.0 to 0.37 and update API usage
- *(readme)* replace demo GIF with asciinema recording and add animated signature header
- *(docs)* remove outdated fix report and update gitignore for architecture documentation
- *(tui/view)* fix rendering order to ensure popup always appears on top of overlay
- *(tui)* implement auto-save on exit and fix overlay save propagation to root form state
- *(tui)* add unit tests for FieldSchema display_label behavior and improve composite_list assertion clarity
- *(tui)* fix popup width calculation and improve composite list multi-choice handling for arrays
- *(ui_ast/tui)* promote plain object arrays to single-variant composites and improve variant title generation
- *(workflows)* migrate from npm to pnpm for web UI builds across all GitHub Actions workflows
- *(tui/app/overlay)* extract popup selection handling logic into dedicated popup_ops submodule
- *(tui/app/overlay)* extract overlay core and opening logic into dedicated submodules
- *(tui/app)* extract overlay input handling and list operations into dedicated submodules
- *(tui/app)* split overlay app module into focused submodules and extract validation logic
- *(tui/app)* extract overlay validation logic and add scalar array overlay test
- *(tui)* remove unused overlay code and clean up imports
- *(tui/app)* extract overlay management logic from runtime module into dedicated overlay/app submodule
- *(tui/app)* extract overlay editor logic into separate state and editor modules
- *(tests)* consolidate test modules under tui directory to match new module structure
- *(readme)* update architecture diagrams and API documentation to reflect tui module consolidation
- *(state)* remove form module and consolidate all state imports to tui::state
- *(form)* remove legacy form/ui module and migrate all UI store code to tui::state::ui_store
- *(lib)* remove app and presentation compatibility shims and migrate all imports to tui module
- *(domain)* remove domain module and migrate all imports to tui::model
- *(tui)* consolidate form state imports to use tui::state module
- *(tui/state)* consolidate domain imports to use tui::model module
- *(tui)* consolidate app and presentation modules into unified tui structure
- *(state)* migrate form state modules from src/form to src/tui/state
- *(schema)* remove domain/schema.rs and migrate form schema building to tui/model module
- *(core)* simplify frontend execution API and remove temporary re-exports
- *(core)* extract shared pipeline and introduce pluggable Frontend trait
- *(tui)* extract TUI session logic into dedicated module
- *(cli)* unify TUI and web frontends under common execution path with enhanced CLI options
- *(web)* rebuild web UI bundle with updated React dependencies
- *(web)* rebuild web UI bundle with updated React dependencies
- *(web)* rebuild web UI bundle with updated React dependencies
- *(web)* rebuild web UI bundle with updated React dependencies
- *(dev)* add development guide and ignore log files
- *(form)* remove unused section_id field from test field schemas
- *(schema)* remove unused section_id field from FieldSchema and improve runtime configuration
- *(ui)* improve variant switching logic for oneOf/anyOf schemas
- *(web)* rebuild web UI bundle with updated React dependencies
- *(web)* rebuild web UI bundle with updated React dependencies
- *(web)* rebuild web UI bundle with updated React dependencies
- *(cli)* introduce modular CLI structure with TUI and web support
- *(composite)* enhance variant selector UI with descriptions and improved layout
- *(web)* rebuild web UI bundle with updated React dependencies
- *(web)* improve UI styling and remove redundant error toasts
- *(web)* rebuild web UI bundle with updated dependencies
- *(web)* rebuild web UI bundle with updated React dependencies
</blockquote>

## `schemaui-cli`

<blockquote>

## [0.2.4](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.3...schemaui-cli-v0.2.4) - 2025-11-23

### Other

- updated the following local packages: schemaui
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).