### PR TITLE
feat(workflows): enhance release workflow with python setup and impro…

### DIFF
--- a/.github/workflows/release-plz-pr.yml
+++ b/.github/workflows/release-plz-pr.yml
@@ -41,21 +41,30 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_PAT }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Update README
-        run: |
-          ./scripts/update-readme.sh
+      - name: Setup Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
 
-          # If README files didn't change, skip commit/push
-          if git diff --quiet -- README*.md; then
-            echo "No README changes; skipping commit."
+      - name: Update CLI dependency and READMEs
+        run: |
+          set -euo pipefail
+
+          ./scripts/update-cli-dependency.sh
+          ./scripts/update-readme-version.sh "$PWD"
+
+          mapfile -t DOC_CHANGES < <(git diff --name-only | grep -E '(^|/)(README[^/]*\.md)$|^schemaui-cli/Cargo\.toml$' || true)
+
+          if [[ ${#DOC_CHANGES[@]} -eq 0 ]]; then
+            echo "No README/CLI dependency changes; skipping commit."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add README*.md
-          git commit -m "Update README.md"
+          git add "${DOC_CHANGES[@]}"
+          git commit -m "Update README and CLI dependency"
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_PAT }}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,6 +30,7 @@
 
 - 更新 Cargo.toml 中的依赖版本
 - 确保依赖兼容性
+- 依赖 `python3`（可通过 `PYTHON_BIN` 环境变量覆盖）
 
 #### update-readme-version.sh
 
@@ -41,6 +42,7 @@
 
 - 自动更新所有 README 中的版本号
 - 保持文档版本一致性
+- 依赖 `python3`（可通过 `PYTHON_BIN` 环境变量覆盖）
 
 ### 发布流程
 

--- a/scripts/update-cli-dependency.sh
+++ b/scripts/update-cli-dependency.sh
@@ -4,7 +4,17 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLI_CARGO="$ROOT_DIR/schemaui-cli/Cargo.toml"
 
-python3 - "$ROOT_DIR" "$CLI_CARGO" <<'PY'
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  if command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python)"
+  else
+    echo "python3 (or override via PYTHON_BIN) is required to run this script." >&2
+    exit 1
+  fi
+fi
+
+"$PYTHON_BIN" - "$ROOT_DIR" "$CLI_CARGO" <<'PY'
 import pathlib
 import re
 import sys

--- a/scripts/update-readme-version.sh
+++ b/scripts/update-readme-version.sh
@@ -3,7 +3,17 @@ set -euo pipefail
 
 START_DIR="${1:-$PWD}"
 
-python3 - "$START_DIR" <<'PY'
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+    if command -v python >/dev/null 2>&1; then
+        PYTHON_BIN="$(command -v python)"
+    else
+        echo "python3 (or override via PYTHON_BIN) is required to update README versions." >&2
+        exit 1
+    fi
+fi
+
+"$PYTHON_BIN" - "$START_DIR" <<'PY'
 import pathlib
 import re
 import sys
@@ -52,7 +62,7 @@ if not pkg_name or not pkg_version:
 pattern = re.compile(rf'({re.escape(pkg_name)}\s*=\s*")([^"]+)(")')
 
 changed = []
-for path in pkg_dir.rglob("*.md"):
+for path in pkg_dir.rglob("README*.md"):
     if any(part in IGNORE_DIRS for part in path.parts):
         continue
     try:

--- a/web/ui/pnpm-workspace.yaml
+++ b/web/ui/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+ignoredBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
…ved doc tracking

- Add explicit Python 3 setup step in release workflow
- Update scripts to use configurable PYTHON_BIN with fallback detection
- Improve change detection for READMEs and Cargo.toml
- Restrict README version updates to README*.md files
- Document python3 dependency in script README

fix(web): ignore esbuild in pnpm workspace builds