### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.4...schemaui-cli-v0.2.5) - 2025-11-24
+
+### Other
+
+- updated the following local packages: schemaui
+
 ## [0.2.4](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.3...schemaui-cli-v0.2.4) - 2025-11-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "schemaui"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "schemaui-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["schemaui-cli"]
 [package]
 name = "schemaui"
 authors = ["unic <yuniqueunic@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 keywords = ["tui", "schema", "configuration", "terminal", "cross-platform"]
 categories = ["command-line-interface", "config"]

--- a/schemaui-cli/Cargo.toml
+++ b/schemaui-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schemaui-cli"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 authors = ["unic <yuniqueunic@gmail.com>"]
 description = "CLI wrapper for schemaui, rendering JSON Schemas as TUIs"
@@ -15,7 +15,7 @@ name = "schemaui"
 path = "src/main.rs"
 
 [dependencies]
-schemaui = { path = "..", version = "0.4.0" }
+schemaui = { path = "..", version = "0.4.1" }
 serde_json = "1"
 color-eyre = "0.6"
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `schemaui`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `schemaui-cli`: 0.2.4 -> 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `schemaui`

<blockquote>

## [0.4.1](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.4.0...schemaui-v0.4.1) - 2025-11-24

### Added

- *(workflows)* enhance release workflow with python setup and improved doc tracking

### Other

- update schemaui dependency version in README files
</blockquote>

## `schemaui-cli`

<blockquote>

## [0.2.5](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.4...schemaui-cli-v0.2.5) - 2025-11-24

### Other

- updated the following local packages: schemaui
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).