### PR TITLE
chore(release): split changelogs for workspace packages

### DIFF
--- a/.github/workflows/release-plz-pr.yml
+++ b/.github/workflows/release-plz-pr.yml
@@ -7,6 +7,7 @@ on:
     # 忽略只修改了这些文件的 push（通常是 release-plz 的更改）
     paths-ignore:
       - "CHANGELOG.md"
+      - "schemaui-cli/CHANGELOG.md"
       - "**/Cargo.toml"
       - "Cargo.lock"
       - "README*.md"
@@ -34,6 +35,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run release-plz PR
+        id: release_plz
         uses: release-plz/action@v0.5
         with:
           command: release-pr
@@ -46,14 +48,41 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Update CLI dependency and READMEs
+      - name: Update release PR docs
+        if: ${{ steps.release_plz.outputs.prs_created == 'true' }}
+        env:
+          PR_JSON: ${{ steps.release_plz.outputs.pr }}
+          PUSH_TOKEN: ${{ secrets.RELEASE_PLZ_PAT }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_PAT }}
         run: |
           set -euo pipefail
+
+          if [[ -z "$PR_JSON" || "$PR_JSON" == "null" ]]; then
+            echo "release-plz did not return PR metadata; skipping doc sync."
+            exit 0
+          fi
+
+          PR_NUMBER="$(echo "$PR_JSON" | jq -r '.number // empty')"
+          HEAD_BRANCH="$(echo "$PR_JSON" | jq -r '.head_branch // empty')"
+          SCHEMAUI_VERSION="$(echo "$PR_JSON" | jq -r '.releases[]? | select(.package_name == "schemaui") | .version' | head -n1)"
+
+          if [[ -z "$PR_NUMBER" || -z "$HEAD_BRANCH" ]]; then
+            echo "Missing PR number or branch; skipping doc sync."
+            exit 0
+          fi
+
+          if [[ -z "$SCHEMAUI_VERSION" || "$SCHEMAUI_VERSION" == "null" ]]; then
+            echo "schemaui not part of this release PR; skipping README sync."
+            exit 0
+          fi
+
+          git fetch origin "$HEAD_BRANCH"
+          git checkout -B "$HEAD_BRANCH" "origin/$HEAD_BRANCH"
 
           ./scripts/update-cli-dependency.sh
           ./scripts/update-readme-version.sh "$PWD"
 
-          mapfile -t DOC_CHANGES < <(git diff --name-only | grep -E '(^|/)(README[^/]*\.md)$|^schemaui-cli/Cargo\.toml$' || true)
+          mapfile -t DOC_CHANGES < <(git diff --name-only -- README*.md schemaui-cli/Cargo.toml || true)
 
           if [[ ${#DOC_CHANGES[@]} -eq 0 ]]; then
             echo "No README/CLI dependency changes; skipping commit."
@@ -62,9 +91,8 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
           git add "${DOC_CHANGES[@]}"
-          git commit -m "Update README and CLI dependency"
-          git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_PAT }}
+          git commit -m "chore: sync README and CLI dependency to $SCHEMAUI_VERSION"
+          git push origin "$HEAD_BRANCH"

--- a/.github/workflows/release-plz-release.yml
+++ b/.github/workflows/release-plz-release.yml
@@ -42,6 +42,11 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: web/ui/pnpm-lock.yaml
 
+      - name: Setup Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
       - name: Build web UI bundle
         working-directory: web/ui
         run: pnpm install --frozen-lockfile && pnpm run build
@@ -69,30 +74,36 @@ jobs:
 
       - name: Sync README versions
         id: sync_readme
+        if: ${{ steps.release_step.outputs.releases_created == 'true' }}
         env:
-          PACKAGE_NAME: ${{ steps.release_step.outputs.package_name }}
-          RELEASE_VERSION: ${{ steps.release_step.outputs.version }}
-        if: ${{ steps.release_step.outputs.version != '' }}
+          RELEASES_JSON: ${{ steps.release_step.outputs.releases }}
+          PUSH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          echo "Package name: $PACKAGE_NAME"
-          echo "Release version: $RELEASE_VERSION"
+          set -euo pipefail
 
-          if [ "$PACKAGE_NAME" != "schemaui" ]; then
-            echo "Skipping README sync because package is $PACKAGE_NAME (not schemaui)"
+          if [[ -z "$RELEASES_JSON" || "$RELEASES_JSON" == "[]" ]]; then
+            echo "Release output is empty; skipping README sync."
             exit 0
           fi
 
-          echo "Syncing README versions to $RELEASE_VERSION"
-          sed -i "s/schemaui = \"[0-9]\+\.[0-9]\+\.[0-9]\+\"/schemaui = \"$RELEASE_VERSION\"/" README.md
-          sed -i "s/schemaui = \"[0-9]\+\.[0-9]\+\.[0-9]\+\"/schemaui = \"$RELEASE_VERSION\"/" README.ZH.md
+          SCHEMAUI_VERSION="$(echo "$RELEASES_JSON" | jq -r '.[] | select(.package_name == "schemaui") | .version' | head -n1)"
 
-          git config user.name "github‑actions[bot]"
-          git config user.email "41898282+github‑actions[bot]@users.noreply.github.com"
-
-          git add README.md README.ZH.md
-          if git diff --cached --quiet; then
-            echo "No README changes detected, skipping commit."
-          else
-            git commit -m "chore: sync version to $RELEASE_VERSION in README files"
-            git push
+          if [[ -z "$SCHEMAUI_VERSION" || "$SCHEMAUI_VERSION" == "null" ]]; then
+            echo "schemaui not part of this release; skipping README sync."
+            exit 0
           fi
+
+          ./scripts/update-readme-version.sh "$PWD"
+
+          if git diff --quiet -- README*.md; then
+            echo "README files already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git add README*.md
+          git commit -m "chore: sync README to $SCHEMAUI_VERSION"
+          git push

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,5 +1,4 @@
 [workspace]
-changelog_path = "CHANGELOG.md"
 changelog_update = true
 dependencies_update = true
 
@@ -16,3 +15,11 @@ semver_check = true
 release_commits = "^(release|feat|fix)[(:]"
 pr_branch_prefix = "release-plz-"
 pr_labels = ["release"]
+
+[[package]]
+name = "schemaui"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "schemaui-cli"
+changelog_path = "schemaui-cli/CHANGELOG.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,33 +5,74 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.5](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.4...schemaui-cli-v0.2.5) - 2025-11-24
+> CLI-specific release notes now live under `schemaui-cli/CHANGELOG.md`.
 
-### Other
-
-- updated the following local packages: schemaui
-
-## [0.2.4](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.3...schemaui-cli-v0.2.4) - 2025-11-23
-
-### Other
-
-- updated the following local packages: schemaui
-
-## [0.2.2](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.1...schemaui-cli-v0.2.2) - 2025-11-16
+## [0.4.0](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.3.3...schemaui-v0.4.0) - 2025-11-23
 
 ### Added
 
-- *(web)* add embedded web UI with `web` feature and CLI subcommand
+- *(tui)* add help overlay with keyboard shortcuts and validation errors, rename ui to backend in demo
+- *(ui)* add variant selector popup for composite list entries with multiple variants
 
 ### Fixed
 
-- *(version)* trigger the release ci/cd.
+- *(tui)* prevent auto-creating new entry when deleting last item from composite list in overlay
+- *(tui)* refactor focus navigation logic in form state
+- *(tests)* enhance route schema and remove outdated overlay tests
+- *(composite)* change anyOf behavior to return single value instead of array
 
 ### Other
 
-- release
-- *(ui)* refactor string literals to double quotes and remove save-and-exit feature
-- update schemaui version and cli installation instructions
+- *(web)* improve array field editing with overlay support and fix composite list rendering
+- *(deps)* upgrade jsonschema from 0.33.0 to 0.37 and update API usage
+- *(readme)* replace demo GIF with asciinema recording and add animated signature header
+- *(docs)* remove outdated fix report and update gitignore for architecture documentation
+- *(tui/view)* fix rendering order to ensure popup always appears on top of overlay
+- *(tui)* implement auto-save on exit and fix overlay save propagation to root form state
+- *(tui)* add unit tests for FieldSchema display_label behavior and improve composite_list assertion clarity
+- *(tui)* fix popup width calculation and improve composite list multi-choice handling for arrays
+- *(ui_ast/tui)* promote plain object arrays to single-variant composites and improve variant title generation
+- *(workflows)* migrate from npm to pnpm for web UI builds across all GitHub Actions workflows
+- *(tui/app/overlay)* extract popup selection handling logic into dedicated popup_ops submodule
+- *(tui/app/overlay)* extract overlay core and opening logic into dedicated submodules
+- *(tui/app)* extract overlay input handling and list operations into dedicated submodules
+- *(tui/app)* split overlay app module into focused submodules and extract validation logic
+- *(tui/app)* extract overlay validation logic and add scalar array overlay test
+- *(tui)* remove unused overlay code and clean up imports
+- *(tui/app)* extract overlay management logic from runtime module into dedicated overlay/app submodule
+- *(tui/app)* extract overlay editor logic into separate state and editor modules
+- *(tests)* consolidate test modules under tui directory to match new module structure
+- *(readme)* update architecture diagrams and API documentation to reflect tui module consolidation
+- *(state)* remove form module and consolidate all state imports to tui::state
+- *(form)* remove legacy form/ui module and migrate all UI store code to tui::state::ui_store
+- *(lib)* remove app and presentation compatibility shims and migrate all imports to tui module
+- *(domain)* remove domain module and migrate all imports to tui::model
+- *(tui)* consolidate form state imports to use tui::state module
+- *(tui/state)* consolidate domain imports to use tui::model module
+- *(tui)* consolidate app and presentation modules into unified tui structure
+- *(state)* migrate form state modules from src/form to src/tui/state
+- *(schema)* remove domain/schema.rs and migrate form schema building to tui/model module
+- *(core)* simplify frontend execution API and remove temporary re-exports
+- *(core)* extract shared pipeline and introduce pluggable Frontend trait
+- *(tui)* extract TUI session logic into dedicated module
+- *(cli)* unify TUI and web frontends under common execution path with enhanced CLI options
+- *(web)* rebuild web UI bundle with updated React dependencies
+- *(web)* rebuild web UI bundle with updated React dependencies
+- *(web)* rebuild web UI bundle with updated React dependencies
+- *(web)* rebuild web UI bundle with updated React dependencies
+- *(dev)* add development guide and ignore log files
+- *(form)* remove unused section_id field from test field schemas
+- *(schema)* remove unused section_id field from FieldSchema and improve runtime configuration
+- *(ui)* improve variant switching logic for oneOf/anyOf schemas
+- *(web)* rebuild web UI bundle with updated React dependencies
+- *(web)* rebuild web UI bundle with updated React dependencies
+- *(web)* rebuild web UI bundle with updated React dependencies
+- *(cli)* introduce modular CLI structure with TUI and web support
+- *(composite)* enhance variant selector UI with descriptions and improved layout
+- *(web)* rebuild web UI bundle with updated React dependencies
+- *(web)* improve UI styling and remove redundant error toasts
+- *(web)* rebuild web UI bundle with updated dependencies
+- *(web)* rebuild web UI bundle with updated React dependencies
 
 ## [0.3.2](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.3.1...schemaui-v0.3.2) - 2025-11-16
 
@@ -48,17 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - *(cd)* update upload-rust-binary-action configuration
-
-## [0.2.1](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.0...schemaui-cli-v0.2.1) - 2025-11-12
-
-### Added
-
-- *(config)* add autocorrect and typos configuration files
-- *(schemaui)* enhance TUI field rendering and navigation
-
-### Other
-
-- *(readme)* improve formatting and fix typos in README files
 
 ## [0.3.0](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.2.0...schemaui-v0.3.0) - 2025-11-12
 

--- a/schemaui-cli/CHANGELOG.md
+++ b/schemaui-cli/CHANGELOG.md
@@ -1,0 +1,41 @@
+# schemaui-cli Changelog
+
+All notable changes to the CLI crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.4](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.3...schemaui-cli-v0.2.4) - 2025-11-23
+
+### Other
+
+- updated the following local packages: schemaui
+
+## [0.2.2](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.1...schemaui-cli-v0.2.2) - 2025-11-16
+
+### Added
+
+- _(web)_ add embedded web UI with `web` feature and CLI subcommand
+
+### Fixed
+
+- _(version)_ trigger the release ci/cd.
+
+### Other
+
+- release
+- _(ui)_ refactor string literals to double quotes and remove save-and-exit
+  feature
+- update schemaui version and cli installation instructions
+
+## [0.2.1](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.2.0...schemaui-cli-v0.2.1) - 2025-11-12
+
+### Added
+
+- _(config)_ add autocorrect and typos configuration files
+- _(schemaui)_ enhance TUI field rendering and navigation
+
+### Other
+
+- _(readme)_ improve formatting and fix typos in README files


### PR DESCRIPTION
Separate the changelog entries for `schemaui` and `schemaui-cli` into their own files. The root `CHANGELOG.md` now only tracks `schemaui` releases, while `schemaui-cli/CHANGELOG.md` handles CLI-specific changes.

Additionally, update release-plz workflow configurations to correctly handle multi-package changelog updates and ensure README version syncing works as expected.