### PR TITLE
ci(cd): update web UI build command to use embedded mode

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Build web UI bundle
         working-directory: web/ui
-        run: pnpm install --frozen-lockfile && pnpm run build
+        run: pnpm install --frozen-lockfile && pnpm run build:embedded
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1.15.2


### PR DESCRIPTION
The build command in the CD workflow has been updated to use the `build:embedded` script instead of the generic `build` script. This change ensures that the web UI is built with the correct configuration for embedded deployments.