### PR TITLE
Enhance/schema validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2601,9 +2601,11 @@ dependencies = [
  "clap",
  "color-eyre",
  "predicates",
+ "reqwest",
  "schemaui",
  "serde_json",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,54 +47,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "anyhow"
@@ -103,10 +59,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "assert_cmd"
-version = "2.2.0"
+name = "argh"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "211818e820cda9ca6f167a64a5c808837366a6dfd807157c64c1304c486cd033"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c442a9d18cef5dde467405d27d461d080d68972d6d0dfd0408265b6749ec427d"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ade012bac4db278517a0132c8c10c6427025868dca16c801087c28d5a411f1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
 dependencies = [
  "anstyle",
  "bstr",
@@ -386,46 +373,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "clap"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,12 +407,6 @@ dependencies = [
  "tracing-core",
  "tracing-error",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1400,12 +1341,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257eb0e588b76827bbddc9e73945a9743693dd2adeaee9da26420f93cfedb798"
+checksum = "84695c6689b01384700a3d93acecbd07231ee6fff1bf22ae980b4c307e6ddfd5"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1643,6 +1578,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "mime"
@@ -1825,12 +1766,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -2305,14 +2240,16 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f38748ceca8d0b0013e60f534d94a6e23dfd89fd2a88318fc5a2d04fda1010"
+checksum = "a2d5554bf79f4acf770dc3193b44b2d63b348f5f7b7448a0ea1191b37b620728"
 dependencies = [
  "ahash",
  "fluent-uri",
  "getrandom 0.3.4",
  "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
  "parking_lot",
  "percent-encoding",
  "serde_json",
@@ -2597,8 +2534,8 @@ dependencies = [
 name = "schemaui-cli"
 version = "0.4.3"
 dependencies = [
+ "argh",
  "assert_cmd",
- "clap",
  "color-eyre",
  "predicates",
  "reqwest",
@@ -3522,11 +3459,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3535,7 +3472,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -4030,6 +3967,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "argh_complete"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8dffc879097ecf0b672f84aaed1268ae6c740e8a7ffc0dd9ef8fd2a731b69"
+dependencies = [
+ "argh_shared",
+]
+
+[[package]]
 name = "argh_derive"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,6 +2544,7 @@ name = "schemaui-cli"
 version = "0.4.3"
 dependencies = [
  "argh",
+ "argh_complete",
  "assert_cmd",
  "color-eyre",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ include = [
 ]
 
 [features]
-default = ["tui", "web", "json"]
+default = ["tui", "json"]
 full = ["all_formats", "tui", "web"]
 tui = []
 web = ["dep:include_dir", "dep:axum", "dep:tokio", "dep:ts-rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ debug = []
 [dependencies]
 anyhow = "1"
 crossterm = "0"
-jsonschema = "0.45"
+jsonschema = "0.46"
 ratatui = "0.30"
 schemars = { version = "0.8.22", features = ["preserve_order"] }
 serde = { version = "1", features = ["derive"] }
@@ -83,7 +83,7 @@ name = "demo"
 path = "examples/demo.rs"
 
 [dev-dependencies]
-reqwest = { version = "0.13.2", features = ["blocking", "json"] }
+reqwest = { version = "0.13", features = ["blocking", "json"] }
 
 [build-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/README.ZH.md
+++ b/README.ZH.md
@@ -185,7 +185,7 @@ fn main() -> color_eyre::Result<()> {
 ## 输入与输出设计
 
 - `io::input::parse_document_str`将
-  JSON/YAML/TOML（通过`serde_json`、`serde_yaml`、`toml`）转换为`serde_json::Value`。功能标志（`json`、`yaml`、`toml`、`all_formats`）不仅控制依赖项，也会真实控制`DocumentFormat`的解析与探测路径。
+  JSON/YAML/TOML（通过`serde_json`、`serde_yaml`、`toml`）转换为`serde_json::Value`。功能标志（`json`、`yaml`、`toml`）不仅控制依赖项，也会真实控制`DocumentFormat`的解析与探测路径。
 - `schema_from_data_value/str`从活动配置中推断模式，注入草稿 -07
   元数据和默认值，以便 UI 加载现有值。
 - `schema_with_defaults`将规范模式与用户数据合并，通过`properties`、`patternProperties`、`additionalProperties`、`dependencies`、`dependentSchemas`、数组和`$ref`目标传播默认值，而不修改原始树。
@@ -451,7 +451,7 @@ schemaui \
 ```
 
 ```
-┌────────┐  clap args   ┌──────────────┐ read stdin/files ┌─────────────┐
+┌────────┐  argh args   ┌──────────────┐ read stdin/files ┌─────────────┐
 │  CLI   ├─────────────▶│ InputSource  ├─────────────────▶│ io::input   │
 └────┬───┘              └──────┬───────┘                  └────┬────────┘
      │ diagnostics             │ schema/default Value          │
@@ -479,6 +479,9 @@ schemaui \
   stdout；如果你明确想走回退文件，可以传`--temp-file <PATH>`。扩展名决定格式；拒绝冲突的扩展名。
 - 标志 –
   `--no-pretty`切换紧凑输出，`--force/--yes`允许覆盖文件，`--title`传递到`SchemaUI::with_title`。
+- Shell completion – `schemaui completion <bash|zsh|fish|nushell>` 会从同一套
+  `argh` 命令树生成补全脚本。PowerShell 暂未暴露，因为上游 `argh_complete`
+  目前没有提供 PowerShell generator。
 
 ## 关键依赖项
 
@@ -491,7 +494,7 @@ schemaui \
 | `crossterm`                                 | 输入路由器消耗的终端事件。                |
 | `indexmap`                                  | 模式遍历的顺序保持映射。                  |
 | `once_cell`                                 | 懒解析快捷键 JSON。                       |
-| `clap`, `color-eyre` (CLI)                  | 参数解析和用户友好的诊断。                |
+| `argh`, `argh_complete`, `color-eyre` (CLI) | 参数解析、Shell 补全生成和友好的诊断。    |
 
 ## 文档映射
 

--- a/README.ZH.md
+++ b/README.ZH.md
@@ -46,6 +46,48 @@
 - **内置 CLI** –
   `schemaui-cli`提供了与库相同的流程，包括多目标输出、stdin/内联规范和聚合诊断。
 
+## Config Schema 自动检测
+
+当你只传 `--config` 而不显式传 `--schema` 时，`schemaui-cli`
+现在会按以下优先级解析 schema：
+
+1. 显式 `--schema`
+2. 配置文件内声明的 schema
+3. `schema_from_data_value` 自动推断
+
+支持的声明形式：
+
+- **JSON**：根级 `$schema`
+- **TOML**：`#:schema ./schema.json`
+- **YAML**：`# yaml-language-server: $schema=...`
+- **YAML fallback**：`# @schema ...`
+
+本地与远程 schema 都支持。相对本地路径会按配置文件所在目录解析；如果配置来自
+stdin/内联文本，则回退到当前工作目录。对于 JSON 配置，根级 `$schema`
+只作为元数据使用，会在内存中的 defaults
+里剥离，避免编辑器提示字段污染最终校验与输出。
+
+远程 `http(s)` schema 加载只存在于 `schemaui-cli`，并且 CLI 默认开启
+`remote-schema` feature；如果你希望二进制只保留本地能力，可以关闭它。 `schemaui`
+这个库默认不会开启任何远程 schema 加载能力。
+
+两者的默认 feature 按使用场景刻意分开：
+
+- `schemaui-cli` 默认走“开箱即用”路径：TUI + Web + 远程 schema 加载都开启。
+- `schemaui` 作为库默认开 `tui + json`，这样保留最基础的 JSON
+  能力，同时不默认引入 Web 与联网相关能力。
+- `json`、`yaml`、`toml` 都是真正落在代码路径上的 feature
+  gate；三者不能全关，否则会直接给出清晰的编译期错误。
+
+参考：
+
+- JSON Schema
+  `$schema`：<https://json-schema.org/understanding-json-schema/reference/schema>
+- Taplo `#:schema`
+  指令：<https://taplo.tamasfe.dev/configuration/directives.html>
+- YAML language server
+  modeline：<https://github.com/redhat-developer/yaml-language-server>
+
 ## 快速开始
 
 ```toml
@@ -143,7 +185,7 @@ fn main() -> color_eyre::Result<()> {
 ## 输入与输出设计
 
 - `io::input::parse_document_str`将
-  JSON/YAML/TOML（通过`serde_json`、`serde_yaml`、`toml`）转换为`serde_json::Value`。功能标志（`json`、`yaml`、`toml`、`all_formats`）保持依赖项精简。
+  JSON/YAML/TOML（通过`serde_json`、`serde_yaml`、`toml`）转换为`serde_json::Value`。功能标志（`json`、`yaml`、`toml`、`all_formats`）不仅控制依赖项，也会真实控制`DocumentFormat`的解析与探测路径。
 - `schema_from_data_value/str`从活动配置中推断模式，注入草稿 -07
   元数据和默认值，以便 UI 加载现有值。
 - `schema_with_defaults`将规范模式与用户数据合并，通过`properties`、`patternProperties`、`additionalProperties`、`dependencies`、`dependentSchemas`、数组和`$ref`目标传播默认值，而不修改原始树。
@@ -433,7 +475,8 @@ schemaui \
 - 诊断 –
   `DiagnosticCollector`累积格式问题、功能标志不匹配、标准输入冲突和现有输出文件，以执行前的诊断。
 - 输出 –
-  `-o/--output`可重复使用，并且可以混合文件路径与`-`用于标准输出。当未设置目标时，工具写入`/tmp/schemaui.json`，除非传递了`--no-temp-file`。扩展名决定格式；拒绝冲突的扩展名。
+  `-o/--output`可重复使用，并且可以混合文件路径与`-`用于标准输出。当未设置目标时，工具直接写到
+  stdout；如果你明确想走回退文件，可以传`--temp-file <PATH>`。扩展名决定格式；拒绝冲突的扩展名。
 - 标志 –
   `--no-pretty`切换紧凑输出，`--force/--yes`允许覆盖文件，`--title`传递到`SchemaUI::with_title`。
 

--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ code change to its architectural responsibility.
 
 - `io::input::parse_document_str` converts JSON/YAML/TOML (via `serde_json`,
   `serde_yaml`, `toml`) into `serde_json::Value`. Feature flags (`json`, `yaml`,
-  `toml`, `all_formats`) keep dependencies lean, and the same gates also drive
-  `DocumentFormat` parsing/probing at compile time.
+  `toml`) keep dependencies lean, and the same gates also drive `DocumentFormat`
+  parsing/probing at compile time.
 - `schema_from_data_value/str` infers schemas from live configs, injecting
   draft-07 metadata and defaults so UIs load pre-existing values.
 - `schema_with_defaults` merges canonical schemas with user data, propagating
@@ -538,7 +538,7 @@ schemaui \
 ```
 
 ```text
-┌────────┐  clap args   ┌──────────────┐ read stdin/files ┌─────────────┐
+┌────────┐  argh args   ┌──────────────┐ read stdin/files ┌─────────────┐
 │  CLI   ├─────────────▶│ InputSource  ├─────────────────▶│ io::input   │
 └────┬───┘              └──────┬───────┘                  └────┬────────┘
      │ diagnostics             │ schema/default Value          │
@@ -567,19 +567,23 @@ schemaui \
   dictate formats; conflicting extensions are rejected.
 - Flags – `--no-pretty` toggles compact output, `--force/--yes` allows
   overwriting files, and `--title` wires through to `SchemaUI::with_title`.
+- Shell completion – `schemaui completion <bash|zsh|fish|nushell>` emits
+  completion scripts from the same `argh` command graph. PowerShell is not
+  exposed yet because upstream `argh_complete` does not currently ship a
+  PowerShell generator.
 
 ## Key Dependencies
 
-| Crate                                       | Purpose                                                     |
-| ------------------------------------------- | ----------------------------------------------------------- |
-| `serde`, `serde_json`, `serde_yaml`, `toml` | Parsing and serializing schema/config data.                 |
-| `schemars`                                  | Draft-07 schema representation used by the `schema` module. |
-| `jsonschema`                                | Runtime validation for forms and overlays.                  |
-| `ratatui`                                   | Rendering widgets, layouts, overlays, and footer.           |
-| `crossterm`                                 | Terminal events consumed by `InputRouter`.                  |
-| `indexmap`                                  | Order-preserving maps for schema traversal.                 |
-| `once_cell`                                 | Lazy parsing of the keymap JSON.                            |
-| `clap`, `color-eyre` (CLI)                  | Argument parsing and ergonomic diagnostics.                 |
+| Crate                                       | Purpose                                                        |
+| ------------------------------------------- | -------------------------------------------------------------- |
+| `serde`, `serde_json`, `serde_yaml`, `toml` | Parsing and serializing schema/config data.                    |
+| `schemars`                                  | Draft-07 schema representation used by the `schema` module.    |
+| `jsonschema`                                | Runtime validation for forms and overlays.                     |
+| `ratatui`                                   | Rendering widgets, layouts, overlays, and footer.              |
+| `crossterm`                                 | Terminal events consumed by `InputRouter`.                     |
+| `indexmap`                                  | Order-preserving maps for schema traversal.                    |
+| `once_cell`                                 | Lazy parsing of the keymap JSON.                               |
+| `argh`, `argh_complete`, `color-eyre` (CLI) | Argument parsing, shell completion, and ergonomic diagnostics. |
 
 ## Documentation Map
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,51 @@ see the full list of issues before saving.
   exposes helpers under `schemaui::web::session` so host applications can serve
   the experience without reimplementing the stack.
 
+## Config Schema Auto-Detection
+
+When you launch the CLI with `--config` and omit `--schema`, `schemaui-cli` now
+resolves the schema in this order:
+
+1. Explicit `--schema`
+2. A schema declaration embedded in the config document
+3. Fallback inference via `schema_from_data_value`
+
+Supported declarations:
+
+- **JSON**: root `$schema`
+- **TOML**: `#:schema ./schema.json`
+- **YAML**: `# yaml-language-server: $schema=...`
+- **YAML fallback**: `# @schema ...`
+
+Both local and remote schema references are supported. Relative local paths are
+resolved against the config file directory, while inline/stdin configs fall back
+to the current working directory. JSON `$schema` metadata is stripped from the
+in-memory defaults before validation/output so editor hints do not leak into the
+final config payload.
+
+Remote `http(s)` schema loading exists only in `schemaui-cli`, and the CLI
+enables the `remote-schema` feature by default. Disable it if you want a
+local-only binary surface; the `schemaui` library crate does not enable any
+remote schema loading by default.
+
+Feature defaults are intentionally split by audience:
+
+- `schemaui-cli` defaults to the convenient, batteries-included path: TUI +
+  Web + remote schema loading.
+- `schemaui` defaults to `tui + json`, so library consumers keep JSON support
+  without pulling in Web or remote/network-related surface area by default.
+- `json`, `yaml`, and `toml` are real code-level gates. Keep at least one of
+  them enabled; disabling all three triggers a clear compile-time error.
+
+References:
+
+- JSON Schema `$schema`:
+  <https://json-schema.org/understanding-json-schema/reference/schema>
+- Taplo directives (`#:schema`):
+  <https://taplo.tamasfe.dev/configuration/directives.html>
+- YAML language server modeline:
+  <https://github.com/redhat-developer/yaml-language-server>
+
 ## Quick Start
 
 ```toml
@@ -153,7 +198,8 @@ code change to its architectural responsibility.
 
 - `io::input::parse_document_str` converts JSON/YAML/TOML (via `serde_json`,
   `serde_yaml`, `toml`) into `serde_json::Value`. Feature flags (`json`, `yaml`,
-  `toml`, `all_formats`) keep dependencies lean.
+  `toml`, `all_formats`) keep dependencies lean, and the same gates also drive
+  `DocumentFormat` parsing/probing at compile time.
 - `schema_from_data_value/str` infers schemas from live configs, injecting
   draft-07 metadata and defaults so UIs load pre-existing values.
 - `schema_with_defaults` merges canonical schemas with user data, propagating
@@ -516,9 +562,9 @@ schemaui \
 - Diagnostics – `DiagnosticCollector` accumulates format issues, feature flag
   mismatches, stdin conflicts, and existing output files before execution.
 - Outputs – `-o/--output` is repeatable and may mix file paths with `-` for
-  stdout. When no destination is set, the tool writes to `/tmp/schemaui.json`
-  unless `--no-temp-file` is passed. Extensions dictate formats; conflicting
-  extensions are rejected.
+  stdout. When no destination is set, the tool writes to stdout; pass
+  `--temp-file <PATH>` if you explicitly want a fallback file. Extensions
+  dictate formats; conflicting extensions are rejected.
 - Flags – `--no-pretty` toggles compact output, `--force/--yes` allows
   overwriting files, and `--title` wires through to `SchemaUI::with_title`.
 

--- a/docs/en/cli_usage.md
+++ b/docs/en/cli_usage.md
@@ -96,7 +96,8 @@ schemaui tui --schema ./schema.json
 
 Key components:
 
-- **`InputSource`** – resolves files vs stdin vs inline specs.
+- **`schema_source`** – resolves explicit `--schema`, config-file declarations,
+  remote/local schema loading, and final fallback inference in one place.
 - **`FormatHint`** – inspects extensions and ensures disabled formats are
   rejected before parsing.
 - **`DiagnosticCollector`** – aggregates every input/output issue and aborts
@@ -106,24 +107,49 @@ Key components:
 
 ## 3. Input Modes
 
-| Flag                  | Behaviour                                            | Notes                                                                           |
-| --------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `-s, --schema <SPEC>` | File path, literal JSON/YAML/TOML, or `-` for stdin. | If the path does not exist the CLI treats the argument as inline text.          |
-| `-c, --config <SPEC>` | Same semantics as `--schema`.                        | Optional; when omitted, defaults are inferred from the config value if present. |
+| Flag                  | Behaviour                                                                      | Notes                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `-s, --schema <SPEC>` | Local path, `file://`, `http(s)://`, literal JSON/YAML/TOML, or `-` for stdin. | Explicit schema wins over any declaration found inside `--config`.                     |
+| `-c, --config <SPEC>` | Same loading semantics as `--schema`.                                          | Optional; if `--schema` is omitted the CLI tries config declarations before inferring. |
 
 Constraints enforced by code:
 
 - `stdin` can only be consumed once, so `--schema -` and `--config -` cannot be
   combined.
-- If only `--config` is provided, the CLI calls `schema_from_data_value` to
-  build a schema with defaults.
+- Resolution priority is: `--schema` > config declaration > inferred schema.
+- Relative local declarations are resolved against the config file's directory.
+  For inline/stdin config payloads, relative paths are resolved against the
+  current working directory.
+- HTTP(S) schema loading is controlled by the `schemaui-cli` `remote-schema`
+  feature, which is enabled by default for the CLI. Local paths and `file://`
+  URLs always work, and the `schemaui` library crate keeps remote schema loading
+  disabled by default. The library crate defaults to `tui + json`, while the CLI
+  defaults to the convenience-oriented feature set.
+- `json`, `yaml`, and `toml` are all real feature gates. Keep at least one of
+  them enabled; disabling all three fails the build with a clear error.
+
+### Config schema auto-detection
+
+When only `--config` is provided, `schemaui-cli` scans the config for a schema
+hint before falling back to `schema_from_data_value`.
+
+Supported declarations:
+
+- **JSON**: root `$schema`
+- **TOML**: `#:schema https://example.com/schema.json`
+- **YAML**: `# yaml-language-server: $schema=...`
+- **YAML fallback**: `# @schema ...`
+
+JSON declarations are treated as metadata, so the root `$schema` key is removed
+from the in-memory defaults before validation/output.
 
 ## 4. Output & Persistence
 
 - `-o, --output <DEST>` is repeatable; pass `-` to include stdout alongside
   files. Extensions (`.json`, `.yaml`, `.toml`) drive `DocumentFormat`.
-- When no destination is set, the CLI writes to `/tmp/schemaui.json` unless
-  `--no-temp-file` is passed or `--temp-file <PATH>` overrides the fallback.
+- When no destination is set, the CLI writes to stdout. Pass
+  `--temp-file
+  <PATH>` if you explicitly want a fallback file instead.
 - `--no-pretty` toggles compact serialization; pretty output is the default.
 - `--force`/`--yes` allows overwriting existing files. Without the flag the CLI
   refuses to run when a destination already exists.
@@ -133,14 +159,14 @@ can reuse the exact same serialization logic.
 
 ## 5. Argument Reference
 
-| Flag                  | Description                                        | Code hook                           |
-| --------------------- | -------------------------------------------------- | ----------------------------------- |
-| `-o, --output <DEST>` | Append destinations (`-` writes to stdout).        | `build_output_options`              |
-| `--title <TEXT>`      | Overrides the TUI title bar.                       | `SchemaUI::with_title`              |
-| `--temp-file <PATH>`  | Custom fallback file when no destinations are set. | `build_output_options`              |
-| `--no-temp-file`      | Disable the fallback file behaviour entirely.      | `build_output_options`              |
-| `--no-pretty`         | Emit compact JSON/TOML/YAML.                       | `OutputOptions::with_pretty(false)` |
-| `--force`, `--yes`    | Allow overwriting files.                           | `ensure_output_paths_available`     |
+| Flag                  | Description                                         | Code hook                           |
+| --------------------- | --------------------------------------------------- | ----------------------------------- |
+| `-o, --output <DEST>` | Append destinations (`-` writes to stdout).         | `build_output_options`              |
+| `--title <TEXT>`      | Overrides the TUI title bar.                        | `SchemaUI::with_title`              |
+| `--temp-file <PATH>`  | Write to this file when no `--output` is given.     | `build_output_options`              |
+| `--no-temp-file`      | Compatibility no-op; stdout is already the default. | `build_output_options`              |
+| `--no-pretty`         | Emit compact JSON/TOML/YAML.                        | `OutputOptions::with_pretty(false)` |
+| `--force`, `--yes`    | Allow overwriting files.                            | `ensure_output_paths_available`     |
 
 ## 6. Usage Examples
 
@@ -158,6 +184,26 @@ schemaui tui \
 
 ```bash
 cat defaults.yaml | schemaui --config - --output ./edited.json
+```
+
+### Config only with schema declaration
+
+```bash
+schemaui web --config ./config.yaml
+```
+
+```yaml
+# yaml-language-server: $schema=./schema.json
+name: api
+port: 8080
+```
+
+### Explicit schema override beats the file header
+
+```bash
+schemaui \
+  --schema https://example.com/runtime.schema.json \
+  --config ./config.toml
 ```
 
 ### Inline schema to avoid double-stdin
@@ -204,15 +250,16 @@ and validation pipeline.
 
 ## 9. Feature Flags
 
-| Feature          | Effect                                                   |
-| ---------------- | -------------------------------------------------------- |
-| `json` (default) | Enables JSON parsing/serialization. Always on.           |
-| `yaml` (default) | Adds YAML parsing/serialization via `serde_yaml`.        |
-| `toml` (opt-in)  | Adds TOML parsing/serialization via `toml`.              |
-| `all_formats`    | Convenience feature: enables `json`, `yaml`, and `toml`. |
+| Feature          | Effect                                                     |
+| ---------------- | ---------------------------------------------------------- |
+| `json` (default) | Enables JSON parsing/serialization and JSON format probes. |
+| `yaml`           | Adds YAML parsing/serialization via `serde_yaml`.          |
+| `toml` (opt-in)  | Adds TOML parsing/serialization via `toml`.                |
+| `all_formats`    | Convenience feature: enables `json`, `yaml`, and `toml`.   |
 
 `DocumentFormat::available_formats()` obeys the same feature matrix, so both the
-CLI and host applications automatically reflect build-time capabilities.
+CLI and host applications automatically reflect build-time capabilities. At
+least one of `json`, `yaml`, or `toml` must remain enabled.
 
 ## 10. Operational Tips
 

--- a/docs/en/cli_usage.md
+++ b/docs/en/cli_usage.md
@@ -2,9 +2,10 @@
 
 `schemaui-cli` is the official command-line wrapper around the `schemaui`
 library. It accepts JSON Schema + config snapshots, defaults to the interactive
-TUI when no mode subcommand is provided, and also exposes explicit `tui`, `web`,
-`tui-snapshot`, and `web-snapshot` subcommands. This guide mirrors the actual
-code in `schemaui-cli/src/main.rs` so the behaviour stays predictable.
+TUI when no mode subcommand is provided, and also exposes explicit `completion`,
+`tui`, `web`, `tui-snapshot`, and `web-snapshot` subcommands. This guide mirrors
+the actual code in `schemaui-cli/src/main.rs` so the behaviour stays
+predictable.
 
 ## 1. Install & Run
 
@@ -70,7 +71,7 @@ repository.
 <!-- AUTO-GENERATED:CLI-INSTALL:END -->
 
 ```bash
-schemaui --help             # binary is named `schemaui` via the clap metadata
+schemaui --help
 ```
 
 If you omit a mode subcommand, `schemaui` falls back to the TUI flow, so the
@@ -81,11 +82,26 @@ schemaui --schema ./schema.json
 schemaui tui --schema ./schema.json
 ```
 
+### Shell completion
+
+`schemaui-cli` now ships an `argh`-backed completion generator:
+
+```bash
+schemaui completion bash > ~/.local/share/bash-completion/completions/schemaui
+schemaui completion zsh > ~/.zfunc/_schemaui
+schemaui completion fish > ~/.config/fish/completions/schemaui.fish
+schemaui completion nushell > ~/.config/nushell/completions/schemaui.nu
+```
+
+Supported shells are `bash`, `zsh`, `fish`, and `nushell`. PowerShell is not
+listed yet because upstream `argh_complete` does not currently ship a PowerShell
+generator.
+
 ## 2. Execution Flow
 
 ```
 ┌────────┐ args┌───────────────┐ schema/config ┌──────────────┐ result ┌────────────┐
-│  clap  ├────▶│ InputSource   ├──────────────▶│ SchemaUI     ├──────▶│ io::output │
+│  argh  ├────▶│ InputSource   ├──────────────▶│ SchemaUI     ├──────▶│ io::output │
 └────┬───┘     └─────────┬─────┘               │ (library)    │        └────┬───────┘
      │ diagnostics       │ format hint         └─────┬────────┘             │  writes
 ┌────▼─────────┐         │ DocumentFormat            │ validator            ▼  files/stdout
@@ -102,6 +118,8 @@ Key components:
   rejected before parsing.
 - **`DiagnosticCollector`** – aggregates every input/output issue and aborts
   early if anything is wrong.
+- **`completion`** – renders shell completion scripts from the same command
+  graph used for runtime parsing.
 - **`SchemaUI`** – same runtime used by library consumers; the CLI only wires up
   arguments.
 
@@ -148,8 +166,7 @@ from the in-memory defaults before validation/output.
 - `-o, --output <DEST>` is repeatable; pass `-` to include stdout alongside
   files. Extensions (`.json`, `.yaml`, `.toml`) drive `DocumentFormat`.
 - When no destination is set, the CLI writes to stdout. Pass
-  `--temp-file
-  <PATH>` if you explicitly want a fallback file instead.
+  `--temp-file <PATH>` if you explicitly want a fallback file instead.
 - `--no-pretty` toggles compact serialization; pretty output is the default.
 - `--force`/`--yes` allows overwriting existing files. Without the flag the CLI
   refuses to run when a destination already exists.
@@ -214,6 +231,12 @@ schemaui tui \
   --config ./config.json -o -
 ```
 
+### Generate a completion script
+
+```bash
+schemaui completion bash
+```
+
 ## 7. Diagnostics & Errors
 
 - **Aggregated reporting** – `DiagnosticCollector` stores every input/output
@@ -250,12 +273,15 @@ and validation pipeline.
 
 ## 9. Feature Flags
 
-| Feature          | Effect                                                     |
-| ---------------- | ---------------------------------------------------------- |
-| `json` (default) | Enables JSON parsing/serialization and JSON format probes. |
-| `yaml`           | Adds YAML parsing/serialization via `serde_yaml`.          |
-| `toml` (opt-in)  | Adds TOML parsing/serialization via `toml`.                |
-| `all_formats`    | Convenience feature: enables `json`, `yaml`, and `toml`.   |
+| Feature                            | Effect                                                            |
+| ---------------------------------- | ----------------------------------------------------------------- |
+| `json`                             | Enables JSON parsing/serialization and JSON format probes.        |
+| `yaml`                             | Adds YAML parsing/serialization via `serde_yaml`.                 |
+| `toml`                             | Adds TOML parsing/serialization via `toml`.                       |
+| `web`                              | Enables the browser UI subcommands and the embedded HTTP runtime. |
+| `full`                             | Convenience feature: enables `json`, `yaml`, `toml`, and `web`.   |
+| `remote-schema`                    | Enables HTTP(S) schema loading through `reqwest`.                 |
+| default (`full` + `remote-schema`) | Matches the convenience-oriented CLI build shipped to end users.  |
 
 `DocumentFormat::available_formats()` obeys the same feature matrix, so both the
 CLI and host applications automatically reflect build-time capabilities. At

--- a/docs/zh/cli_usage.zh.md
+++ b/docs/zh/cli_usage.zh.md
@@ -2,8 +2,8 @@
 
 `schemaui-cli` 是 `schemaui` 库的官方命令行包装器。它接受 JSON Schema +
 配置快照；当未显式指定模式子命令时默认启动交互式 TUI，同时也暴露显式的
-`tui`、`web`、`tui-snapshot`、`web-snapshot` 子命令。本指南与
-`schemaui-cli/src/main.rs` 中的实际代码保持一致，以确保行为的可预测性。
+`completion`、`tui`、`web`、`tui-snapshot`、`web-snapshot` 子命令。本指南与
+`schemaui-cli/src/main.rs` 中的实际代码保持一致，以确保行为可预测。
 
 ## 1. 安装与运行
 
@@ -17,7 +17,7 @@ cargo run -p schemaui-cli -- tui --schema ./schema.json --config ./config.yaml
 
 ```bash
 cargo install schemaui-cli
-schemaui --help             # 二进制文件通过 clap 元数据命名为 `schemaui`
+schemaui --help
 ```
 
 如果省略模式子命令，`schemaui` 会回退到默认的 TUI 流程，因此下面两种写法等价：
@@ -27,11 +27,25 @@ schemaui --schema ./schema.json
 schemaui tui --schema ./schema.json
 ```
 
+### Shell completion
+
+`schemaui-cli` 现在内置了基于 `argh_complete` 的补全脚本生成能力：
+
+```bash
+schemaui completion bash > ~/.local/share/bash-completion/completions/schemaui
+schemaui completion zsh > ~/.zfunc/_schemaui
+schemaui completion fish > ~/.config/fish/completions/schemaui.fish
+schemaui completion nushell > ~/.config/nushell/completions/schemaui.nu
+```
+
+当前官方支持的 shell 是 `bash`、`zsh`、`fish`、`nushell`。PowerShell
+还没有接入，因为上游 `argh_complete` 目前没有提供 PowerShell generator。
+
 ## 2. 执行流程
 
 ```
 ┌────────┐ args┌───────────────┐ schema/config ┌──────────────┐ result ┌────────────┐
-│  clap  ├────▶│ InputSource   ├──────────────▶│ SchemaUI     ├──────▶│ io::output │
+│  argh  ├────▶│ InputSource   ├──────────────▶│ SchemaUI     ├──────▶│ io::output │
 └────┬───┘     └─────────┬─────┘               │ (library)    │        └────┬───────┘
      │ diagnostics       │ format hint         └─────┬────────┘             │  writes
 ┌────▼─────────┐         │ DocumentFormat            │ validator            ▼  files/stdout
@@ -42,52 +56,75 @@ schemaui tui --schema ./schema.json
 
 关键组件：
 
-- **`InputSource`** – 解析文件、stdin 或内联规范。
-- **`FormatHint`** – 检查扩展名并确保在解析前拒绝已禁用的格式。
-- **`DiagnosticCollector`** –
-  汇总每个输入/输出问题，如果出现任何错误则提前中止。
-- **`SchemaUI`** – 与库消费者使用的相同运行时；CLI 仅负责连接参数。
+- **`schema_source`**：统一处理显式 `--schema`、配置文件内声明、远程/本地 schema
+  加载，以及最终的兜底推断。
+- **`FormatHint`**：根据扩展名检查格式，并在真正解析前拦截被 feature
+  关闭的格式。
+- **`DiagnosticCollector`**：聚合每个输入/输出问题，出错时统一中止。
+- **`completion`**：基于同一套命令树渲染 shell completion 脚本。
+- **`SchemaUI`**：CLI 复用的仍然是库中的同一套运行时能力。
 
 ## 3. 输入模式
 
-| 标志                  | 行为                                              | 注意事项                                         |
-| --------------------- | ------------------------------------------------- | ------------------------------------------------ |
-| `-s, --schema <SPEC>` | 文件路径、字面 JSON/YAML/TOML 或 `-` 表示 stdin。 | 如果路径不存在，CLI 会将参数视为内联文本。       |
-| `-c, --config <SPEC>` | 与 `--schema` 相同的语义。                        | 可选；省略时，如果存在配置值，则从中推断默认值。 |
+| 标志                  | 行为                                                                        | 注意事项                                                         |
+| --------------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `-s, --schema <SPEC>` | 本地路径、`file://`、`http(s)://`、内联 JSON/YAML/TOML，或 `-` 表示 stdin。 | 显式 schema 的优先级高于 `--config` 中发现的任何 schema 声明。   |
+| `-c, --config <SPEC>` | 与 `--schema` 相同的加载语义。                                              | 可选；省略 `--schema` 时，CLI 会先尝试配置内声明，再做兜底推断。 |
 
-代码强制执行的约束：
+代码层强制执行的约束：
 
 - `stdin` 只能使用一次，因此 `--schema -` 和 `--config -` 不能同时使用。
-- 如果仅提供 `--config`，CLI 会调用 `schema_from_data_value` 来构建带有默认值的
-  schema。
+- 优先级为：`--schema` > 配置声明 > 推断 schema。
+- 相对本地声明路径会相对 `--config` 所在目录解析。
+- 若配置来自内联文本或 stdin，相对路径会相对当前工作目录解析。
+- HTTP(S) schema 加载由 `schemaui-cli` 的 `remote-schema` feature 控制。CLI
+  默认启用； `schemaui` 库默认关闭远程 schema 加载。
+- `schemaui` 库默认 feature 为 `tui + json`；CLI 默认 feature 为
+  `full + remote-schema`。
+- `json`、`yaml`、`toml` 都是真实的 feature
+  gate；三者全关时，编译会直接报清晰错误。
+
+### 配置 schema 自动检测
+
+当只传 `--config` 时，`schemaui-cli` 会先扫描配置中的 schema 声明，再回退到
+`schema_from_data_value`。
+
+支持的声明格式：
+
+- **JSON**：根级 `$schema`
+- **TOML**：`#:schema https://example.com/schema.json`
+- **YAML**：`# yaml-language-server: $schema=...`
+- **YAML 兜底**：`# @schema ...`
+
+对于 JSON，根级 `$schema`
+被视为元数据，因此在内存中的默认值会先移除该字段，再参与 校验与输出。
 
 ## 4. 输出与持久化
 
-- `-o, --output <DEST>` 可重复；传递 `-` 可在文件之外包含
-  stdout。扩展名（`.json`、`.yaml`、`.toml`）驱动 `DocumentFormat`。
-- 当未设置目的地时，CLI 会写入 `/tmp/schemaui.json`，除非传递了 `--no-temp-file`
-  或 `--temp-file <PATH>` 覆盖回退路径。
-- `--no-pretty` 切换紧凑序列化；默认为美化输出。
-- `--force`/`--yes` 允许覆盖现有文件。如果没有此标志，当目标文件已存在时，CLI
-  会拒绝运行。
+- `-o, --output <DEST>` 可重复传递；`-` 表示写到 stdout。
+- 输出扩展名（`.json`、`.yaml`、`.toml`）决定 `DocumentFormat`。
+- 当未指定任何目标时，CLI 默认写到 stdout；如果你明确想走回退文件，再显式传
+  `--temp-file <PATH>`。
+- `--no-pretty` 切换为紧凑序列化；默认是 pretty 输出。
+- `--force` / `--yes` 允许覆盖已有文件；否则遇到已存在目标会直接拒绝执行。
 
-内部由 `io::output::OutputOptions`
-提供支持，因此嵌入项目可以重用完全相同的序列化逻辑。
+这些行为都由 `io::output::OutputOptions`
+驱动，因此嵌入方可以复用完全相同的输出逻辑。
 
 ## 5. 参数参考
 
-| 标志                  | 描述                           | 代码钩子                            |
-| --------------------- | ------------------------------ | ----------------------------------- |
-| `-o, --output <DEST>` | 追加目标（`-` 写入 stdout）。  | `build_output_options`              |
-| `--title <TEXT>`      | 覆盖 TUI 标题栏。              | `SchemaUI::with_title`              |
-| `--temp-file <PATH>`  | 未设置目标时的自定义回退文件。 | `build_output_options`              |
-| `--no-temp-file`      | 完全禁用回退文件行为。         | `build_output_options`              |
-| `--no-pretty`         | 输出紧凑的 JSON/TOML/YAML。    | `OutputOptions::with_pretty(false)` |
-| `--force`, `--yes`    | 允许覆盖文件。                 | `ensure_output_paths_available`     |
+| 标志                  | 描述                                    | 代码钩子                            |
+| --------------------- | --------------------------------------- | ----------------------------------- |
+| `-o, --output <DEST>` | 追加输出目标（`-` 写到 stdout）。       | `build_output_options`              |
+| `--title <TEXT>`      | 覆盖 TUI 标题栏。                       | `SchemaUI::with_title`              |
+| `--temp-file <PATH>`  | 未设置 `--output` 时，显式写到该文件。  | `build_output_options`              |
+| `--no-temp-file`      | 兼容性 no-op；默认行为本来就是 stdout。 | `build_output_options`              |
+| `--no-pretty`         | 输出紧凑 JSON/TOML/YAML。               | `OutputOptions::with_pretty(false)` |
+| `--force`, `--yes`    | 允许覆盖现有文件。                      | `ensure_output_paths_available`     |
 
 ## 6. 使用示例
 
-### Schema + config + 双输出
+### schema + config + 双输出
 
 ```bash
 schemaui tui \
@@ -103,7 +140,27 @@ schemaui tui \
 cat defaults.yaml | schemaui --config - --output ./edited.json
 ```
 
-### 内联 schema 以避免双 stdin
+### 仅 config，但使用文件头中的 schema 声明
+
+```bash
+schemaui web --config ./config.yaml
+```
+
+```yaml
+# yaml-language-server: $schema=./schema.json
+name: api
+port: 8080
+```
+
+### 显式 schema 覆盖文件头声明
+
+```bash
+schemaui \
+  --schema https://example.com/runtime.schema.json \
+  --config ./config.toml
+```
+
+### 用内联 schema 避免双 stdin
 
 ```bash
 schemaui tui \
@@ -111,20 +168,23 @@ schemaui tui \
   --config ./config.json -o -
 ```
 
+### 生成 completion 脚本
+
+```bash
+schemaui completion bash
+```
+
 ## 7. 诊断与错误
 
-- **汇总报告** – `DiagnosticCollector` 存储每个输入/输出问题（冲突的
-  stdin、禁用的格式、现有文件），并在以非零代码退出之前将它们打印为编号列表。
-- **格式推断** – `resolve_format_hint`
-  在扩展名需要已禁用的功能时发出警告（例如，没有 `yaml` 功能时使用
-  `.yaml`）。CLI 立即停止，而不是稍后在序列化期间失败。
-- **运行时错误** – 其他所有内容都通过 `color-eyre`
-  冒泡，因此堆栈跟踪包含上下文，如 `failed to parse config as yaml` 或
-  `failed to compile JSON schema`。
+- **聚合报告**：`DiagnosticCollector` 会把冲突
+  stdin、格式被禁用、输出文件已存在等问题 聚合成编号列表，再以非零状态退出。
+- **格式推断**：当扩展名要求的格式 feature 没开时，CLI 会在解析前直接停止。
+- **运行时错误**：其余错误经由 `color-eyre` 输出上下文，例如
+  `failed to parse config as yaml` 或 `failed to compile JSON schema`。
 
 ## 8. 库互操作
 
-CLI 是 `SchemaUI` 的薄包装器：
+CLI 只是 `SchemaUI` 的一层薄包装：
 
 ```rust
 let mut ui = SchemaUI::new(schema);
@@ -140,25 +200,34 @@ if let Some(options) = output_settings {
 ui.run()?;
 ```
 
-这意味着嵌入项目可以逐字重现 CLI 流程，或完全替换前端（例如，构建自定义 CLI 或
-GUI），同时重用相同的 I/O 和验证管道。
+这意味着嵌入项目既可以原样复刻 CLI 行为，也可以替换前端，只复用同一套 I/O
+与校验链路。
 
-## 9. 功能标志
+## 9. Feature Flags
 
-| 功能           | 效果                                      |
-| -------------- | ----------------------------------------- |
-| `json`（默认） | 启用 JSON 解析/序列化。始终开启。         |
-| `yaml`（默认） | 通过 `serde_yaml` 添加 YAML 解析/序列化。 |
-| `toml`（可选） | 通过 `toml` 添加 TOML 解析/序列化。       |
-| `all_formats`  | 便利功能：启用 `json`、`yaml` 和 `toml`。 |
+| Feature                          | 作用                                           |
+| -------------------------------- | ---------------------------------------------- |
+| `json`                           | 启用 JSON 解析/序列化以及 JSON 格式探测。      |
+| `yaml`                           | 通过 `serde_yaml` 启用 YAML 解析/序列化。      |
+| `toml`                           | 通过 `toml` 启用 TOML 解析/序列化。            |
+| `web`                            | 启用浏览器 UI 子命令以及内嵌 HTTP 运行时。     |
+| `full`                           | 便利组合：启用 `json`、`yaml`、`toml`、`web`。 |
+| `remote-schema`                  | 通过 `reqwest` 启用 HTTP(S) schema 加载。      |
+| 默认值（`full + remote-schema`） | 对最终 CLI 用户开放的开箱即用构建。            |
 
-`DocumentFormat::available_formats()` 遵循相同的功能矩阵，因此 CLI
-和宿主应用程序都会自动反映构建时的能力。
+`DocumentFormat::available_formats()` 会自动反映同一套 feature 矩阵。至少保留
+`json`、`yaml`、`toml` 中的一个。
 
-## 10. Web 模式
+## 10. 操作提示
 
-当在启用 `web` 功能（默认启用）的构建下运行时，`schemaui-cli` 暴露 `web`
-子命令，用于代理库提供的浏览器 UI：
+- 如果 schema 和 config 都想走
+  stdin，就把其中一个改为内联文本；可执行文件只会消费一次 stdin。
+- 输出最好总是带扩展名；格式推断使用第一个文件的后缀，跨文件冲突会被直接拒绝。
+- 可以把 `-o -` 和文件输出同时使用，这样既能进 CI 日志，也能真正落盘。
+
+## 11. Web 模式
+
+启用 `web` feature（CLI 默认启用）后，`schemaui-cli` 会暴露 `web` 子命令：
 
 ```bash
 schemaui web \
@@ -168,29 +237,18 @@ schemaui web \
   -o -
 ```
 
-该命令重用与 TUI 流程相同的 schema/config 管道，然后调用
-`schemaui::web::session::bind_session` 将静态资源和 HTTP API 嵌入到临时 HTTP
-服务中。终端会打印绑定地址（端口为 `0` 时选择一个随机空闲端口）。
+该命令与 TUI 共用同一套 schema/config 加载链路，然后调用
+`schemaui::web::session::bind_session` 启动临时 HTTP 服务并挂载静态资源与 API。
+终端会打印绑定地址；如果端口传 `0`，则自动选择随机空闲端口。
 
-- 点击 **Save** 可以在不退出的情况下持久化编辑结果；
-- 点击 **Save & Exit** 会关闭临时服务器，并通过配置好的输出目标 发出最终 JSON。
+- 点击 **Save** 可以在不退出页面的情况下持久化当前编辑内容。
+- 点击 **Save & Exit** 会关闭临时服务，并把最终结果写到配置好的输出目标。
 
-`web` 子命令特有的参数：
+`web` 子命令额外参数：
 
-| 标志            | 描述                               |
-| --------------- | ---------------------------------- |
-| `--host <IP>`   | 临时 HTTP 服务器的绑定地址。       |
-| `--port <PORT>` | 绑定端口（`0` 表示请求临时端口）。 |
+| 标志            | 描述                                 |
+| --------------- | ------------------------------------ |
+| `--host <IP>`   | 临时 HTTP 服务绑定地址。             |
+| `--port <PORT>` | 绑定端口；`0` 表示请求随机空闲端口。 |
 
-其他参数（`--schema`、`--config`、`--output` 等）的行为与 TUI 模式完全一致：
-同样支持文件/内联规范、多个输出目标以及汇总诊断。
-
-## 11. 操作提示
-
-- 当 schema 和 config 都需要 stdin
-  时，将一个流作为字面文本传递（不存在的路径被视为内联）；可执行文件只读取 stdin
-  一次。
-- 为输出提供明确的扩展名——格式推断使用第一个文件的后缀，跨文件的不匹配将被拒绝。
-- 将 `-o -` 与文件输出结合使用，可以在写入磁盘的同时将结果传输到 CI 日志中。
-
-使用这些模式，您可以在 CI/CD 管道或开发者工具中自信地编写 `schemaui-cli` 脚本。
+其他参数（`--schema`、`--config`、`--output` 等）与 TUI 模式完全一致。

--- a/schemaui-cli/Cargo.toml
+++ b/schemaui-cli/Cargo.toml
@@ -27,10 +27,10 @@ path = "src/main.rs"
 [dependencies]
 schemaui = { path = "..", version = "0.7.2", default-features = false, features = ["tui"] }
 serde_json = "1"
-color-eyre = "0.6.5"
-clap = { version = "4.6.0", features = ["derive"] }
-tokio = { version = "1.50.0", features = ["rt-multi-thread"], optional = true }
-reqwest = { version = "0.13.2", features = ["blocking"], optional = true }
+color-eyre = "0.6"
+argh = "0.1"
+tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
+reqwest = { version = "0.13", features = ["blocking"], optional = true }
 url = "2"
 
 [features]
@@ -43,5 +43,5 @@ web = ["schemaui/web", "dep:tokio"]
 remote-schema = ["dep:reqwest"]
 
 [dev-dependencies]
-assert_cmd = "2.2.0"
-predicates = "3.1.4"
+assert_cmd = "2"
+predicates = "3"

--- a/schemaui-cli/Cargo.toml
+++ b/schemaui-cli/Cargo.toml
@@ -25,19 +25,22 @@ name = "schemaui"
 path = "src/main.rs"
 
 [dependencies]
-schemaui = { path = "..", version = "0.7.2" }
+schemaui = { path = "..", version = "0.7.2", default-features = false, features = ["tui"] }
 serde_json = "1"
 color-eyre = "0.6.5"
 clap = { version = "4.6.0", features = ["derive"] }
 tokio = { version = "1.50.0", features = ["rt-multi-thread"], optional = true }
+reqwest = { version = "0.13.2", features = ["blocking"], optional = true }
+url = "2"
 
 [features]
-default = ["full", "web"]
+default = ["full", "remote-schema"]
 full = ["json", "yaml", "toml", "web"]
 json = ["schemaui/json"]
 yaml = ["schemaui/yaml"]
 toml = ["schemaui/toml"]
 web = ["schemaui/web", "dep:tokio"]
+remote-schema = ["dep:reqwest"]
 
 [dev-dependencies]
 assert_cmd = "2.2.0"

--- a/schemaui-cli/Cargo.toml
+++ b/schemaui-cli/Cargo.toml
@@ -29,6 +29,7 @@ schemaui = { path = "..", version = "0.7.2", default-features = false, features 
 serde_json = "1"
 color-eyre = "0.6"
 argh = "0.1"
+argh_complete = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
 reqwest = { version = "0.13", features = ["blocking"], optional = true }
 url = "2"

--- a/schemaui-cli/src/cli.rs
+++ b/schemaui-cli/src/cli.rs
@@ -1,144 +1,643 @@
 use std::path::PathBuf;
 
-use clap::{ArgAction, Args, Parser, Subcommand};
+use argh::FromArgs;
 
 #[cfg(feature = "web")]
 use std::net::IpAddr;
 
-#[derive(Debug, Parser)]
-#[command(
-    name = "schemaui",
-    version,
-    about = "Render JSON Schemas as interactive TUIs or Web UIs"
-)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Cli {
-    #[command(flatten)]
     pub common: CommonArgs,
-
-    #[command(subcommand)]
     pub command: Option<Commands>,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Commands {
-    /// Launch the interactive terminal UI
     Tui(TuiCommand),
-
     #[cfg(feature = "web")]
-    /// Launch the interactive web UI instead of the terminal UI
     Web(WebCommand),
-
     #[cfg(feature = "web")]
-    /// Precompute Web session snapshots instead of launching the UI
     WebSnapshot(WebSnapshotCommand),
-
-    /// Precompute TUI FormSchema/LayoutNavModel modules instead of launching the UI
     TuiSnapshot(TuiSnapshotCommand),
 }
 
-#[derive(Debug, Args, Clone)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TuiCommand {
-    #[command(flatten)]
     pub common: CommonArgs,
 }
 
 #[cfg(feature = "web")]
-#[derive(Debug, Args, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WebCommand {
-    #[command(flatten)]
     pub common: CommonArgs,
-
-    /// Bind address for the temporary HTTP server
-    #[rustfmt::skip]
-    #[arg(alias = "bind", alias = "listen")]
-    #[arg( short = 'l', long = "host", value_name = "IP", default_value = "127.0.0.1" )]
     pub host: IpAddr,
-
-    /// Bind port for the temporary HTTP server (0 picks a random free port)
-    #[arg(short = 'p', long = "port", value_name = "PORT", default_value_t = 0)]
     pub port: u16,
 }
 
 #[cfg(feature = "web")]
-#[derive(Debug, Args, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WebSnapshotCommand {
-    #[command(flatten)]
     pub common: CommonArgs,
-
-    /// Output directory for generated Web snapshots (JSON + TS)
-    #[arg(long = "out-dir", value_name = "DIR", default_value = "web_snapshots")]
     pub out_dir: PathBuf,
-
-    /// Name of the exported constant in the generated TS module
-    #[arg(
-        long = "ts-export",
-        value_name = "NAME",
-        default_value = "SessionSnapshot"
-    )]
     pub ts_export: String,
 }
 
-#[derive(Debug, Args, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TuiSnapshotCommand {
-    #[command(flatten)]
     pub common: CommonArgs,
-
-    /// Output directory for generated TUI artifact modules (Rust source)
-    #[arg(long = "out-dir", value_name = "DIR", default_value = "tui_artifacts")]
     pub out_dir: PathBuf,
-
-    /// Name of the generated TuiArtifacts constructor function
-    #[arg(long = "tui-fn", value_name = "NAME", default_value = "tui_artifacts")]
     pub tui_fn: String,
-
-    /// Name of the generated FormSchema constructor function
-    #[arg(
-        long = "form-fn",
-        value_name = "NAME",
-        default_value = "tui_form_schema"
-    )]
     pub form_fn: String,
-
-    /// Name of the generated LayoutNavModel constructor function
-    #[arg(
-        long = "layout-fn",
-        value_name = "NAME",
-        default_value = "tui_layout_nav"
-    )]
     pub layout_fn: String,
 }
 
-#[derive(Debug, Args, Clone)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CommonArgs {
-    /// Schema spec: local path, file/HTTP URL, inline payload, or "-" for stdin
-    #[arg(short = 's', long = "schema", value_name = "SPEC")]
     pub schema: Option<String>,
-
-    /// Config spec: local path, file/HTTP URL, inline payload, or "-" for stdin
-    #[arg(short = 'c', long = "config", alias = "data", value_name = "SPEC")]
     pub config: Option<String>,
-
-    /// Title shown at the top of the UI
-    #[arg(long = "title", value_name = "TEXT")]
     pub title: Option<String>,
-
-    /// Output destinations ("-" writes to stdout). Accepts multiple values per flag use.
-    #[arg(short = 'o', long = "output", value_name = "DEST", num_args = 1.., action = ArgAction::Append)]
     pub outputs: Vec<String>,
-
-    /// Write to PATH when no destinations are set (stdout remains the default)
-    #[arg(long = "temp-file", value_name = "PATH")]
     pub temp_file: Option<PathBuf>,
-
-    /// Compatibility no-op: stdout is already the default when no destinations are set
-    #[arg(long = "no-temp-file", conflicts_with = "temp_file")]
     pub no_temp_file: bool,
-
-    /// Emit compact JSON/TOML rather than pretty formatting
-    #[arg(long = "no-pretty")]
     pub no_pretty: bool,
-
-    /// Overwrite output files even if they already exist
-    #[arg(short = 'f', long = "force", short_alias = 'y', alias = "yes")]
     pub force: bool,
+}
+
+impl CommonArgs {
+    pub fn merged_with(&self, local: &Self) -> Self {
+        let mut outputs = self.outputs.clone();
+        outputs.extend(local.outputs.clone());
+
+        Self {
+            schema: local.schema.clone().or_else(|| self.schema.clone()),
+            config: local.config.clone().or_else(|| self.config.clone()),
+            title: local.title.clone().or_else(|| self.title.clone()),
+            outputs,
+            temp_file: local.temp_file.clone().or_else(|| self.temp_file.clone()),
+            no_temp_file: self.no_temp_file || local.no_temp_file,
+            no_pretty: self.no_pretty || local.no_pretty,
+            force: self.force || local.force,
+        }
+    }
+}
+
+impl Cli {
+    pub fn parse() -> Self {
+        Self::from_env_or_exit()
+    }
+
+    pub fn from_env_or_exit() -> Self {
+        match Self::try_parse_from(std::env::args()) {
+            Ok(cli) => cli,
+            Err(exit) => {
+                if exit.status.is_ok() {
+                    print!("{}", exit.output);
+                    std::process::exit(0);
+                }
+                eprint!("{}", exit.output);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    pub fn parse_from<I, T>(args: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<String>,
+    {
+        Self::try_parse_from(args).unwrap_or_else(|exit| {
+            panic!("failed to parse args: {}", exit.output);
+        })
+    }
+
+    pub fn try_parse_from<I, T>(args: I) -> Result<Self, argh::EarlyExit>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<String>,
+    {
+        let raw = args.into_iter().map(Into::into).collect::<Vec<_>>();
+        let program = raw
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "schemaui".to_string());
+
+        let normalized = normalize_args(&raw[1..]);
+        let scan = scan_for_command(&normalized);
+        let mut parse_args = normalized.clone();
+        let injected_default_tui = matches!(scan, CommandScan::None);
+        if injected_default_tui {
+            parse_args.push("tui".to_string());
+        }
+        let parse_args = expand_output_values(&parse_args);
+        let parse_refs = parse_args.iter().map(String::as_str).collect::<Vec<_>>();
+        let parsed = ArghCli::from_args(&[program.as_str()], &parse_refs)?;
+        Ok(Self::from_argh(parsed, injected_default_tui))
+    }
+
+    fn from_argh(parsed: ArghCli, injected_default_tui: bool) -> Self {
+        let common = common_args_from_root(&parsed);
+        match parsed.command {
+            ArghCommands::Tui(_command) if injected_default_tui => Self {
+                common,
+                command: None,
+            },
+            ArghCommands::Tui(command) => Self {
+                common,
+                command: Some(Commands::Tui(TuiCommand {
+                    common: common_args_from_tui(command),
+                })),
+            },
+            #[cfg(feature = "web")]
+            ArghCommands::Web(command) => Self {
+                common,
+                command: Some(Commands::Web(WebCommand {
+                    common: common_args_from_web(&command),
+                    host: command.host,
+                    port: command.port,
+                })),
+            },
+            #[cfg(feature = "web")]
+            ArghCommands::WebSnapshot(command) => Self {
+                common,
+                command: Some(Commands::WebSnapshot(WebSnapshotCommand {
+                    common: common_args_from_web_snapshot(&command),
+                    out_dir: command.out_dir,
+                    ts_export: command.ts_export,
+                })),
+            },
+            ArghCommands::TuiSnapshot(command) => Self {
+                common,
+                command: Some(Commands::TuiSnapshot(TuiSnapshotCommand {
+                    common: common_args_from_tui_snapshot(&command),
+                    out_dir: command.out_dir,
+                    tui_fn: command.tui_fn,
+                    form_fn: command.form_fn,
+                    layout_fn: command.layout_fn,
+                })),
+            },
+        }
+    }
+}
+
+fn common_args_from_root(args: &ArghCli) -> CommonArgs {
+    CommonArgs {
+        schema: args.schema.clone(),
+        config: args.config.clone(),
+        title: args.title.clone(),
+        outputs: args.outputs.clone(),
+        temp_file: args.temp_file.clone(),
+        no_temp_file: args.no_temp_file,
+        no_pretty: args.no_pretty,
+        force: args.force,
+    }
+}
+
+fn common_args_from_tui(args: ArghTuiCommand) -> CommonArgs {
+    CommonArgs {
+        schema: args.schema,
+        config: args.config,
+        title: args.title,
+        outputs: args.outputs,
+        temp_file: args.temp_file,
+        no_temp_file: args.no_temp_file,
+        no_pretty: args.no_pretty,
+        force: args.force,
+    }
+}
+
+#[cfg(feature = "web")]
+fn common_args_from_web(args: &ArghWebCommand) -> CommonArgs {
+    CommonArgs {
+        schema: args.schema.clone(),
+        config: args.config.clone(),
+        title: args.title.clone(),
+        outputs: args.outputs.clone(),
+        temp_file: args.temp_file.clone(),
+        no_temp_file: args.no_temp_file,
+        no_pretty: args.no_pretty,
+        force: args.force,
+    }
+}
+
+#[cfg(feature = "web")]
+fn common_args_from_web_snapshot(args: &ArghWebSnapshotCommand) -> CommonArgs {
+    CommonArgs {
+        schema: args.schema.clone(),
+        config: args.config.clone(),
+        title: args.title.clone(),
+        outputs: args.outputs.clone(),
+        temp_file: args.temp_file.clone(),
+        no_temp_file: args.no_temp_file,
+        no_pretty: args.no_pretty,
+        force: args.force,
+    }
+}
+
+fn common_args_from_tui_snapshot(args: &ArghTuiSnapshotCommand) -> CommonArgs {
+    CommonArgs {
+        schema: args.schema.clone(),
+        config: args.config.clone(),
+        title: args.title.clone(),
+        outputs: args.outputs.clone(),
+        temp_file: args.temp_file.clone(),
+        no_temp_file: args.no_temp_file,
+        no_pretty: args.no_pretty,
+        force: args.force,
+    }
+}
+
+#[derive(FromArgs, Debug, PartialEq)]
+#[argh(help_triggers("-h", "--help", "help"))]
+/// Render JSON Schemas as interactive TUIs or Web UIs
+struct ArghCli {
+    /// schema spec: local path, file/HTTP URL, inline payload, or "-" for stdin
+    #[argh(option, short = 's')]
+    schema: Option<String>,
+
+    /// config spec: local path, file/HTTP URL, inline payload, or "-" for stdin
+    #[argh(option, short = 'c')]
+    config: Option<String>,
+
+    /// title shown at the top of the UI
+    #[argh(option)]
+    title: Option<String>,
+
+    /// output destinations ("-" writes to stdout). Repeat the flag to add more.
+    #[argh(option, short = 'o')]
+    outputs: Vec<String>,
+
+    /// write to PATH when no destinations are set (stdout remains the default)
+    #[argh(option)]
+    temp_file: Option<PathBuf>,
+
+    /// compatibility no-op: stdout is already the default when no destinations are set
+    #[argh(switch)]
+    no_temp_file: bool,
+
+    /// emit compact JSON/TOML rather than pretty formatting
+    #[argh(switch)]
+    no_pretty: bool,
+
+    /// overwrite output files even if they already exist
+    #[argh(switch, short = 'f')]
+    force: bool,
+
+    #[argh(subcommand)]
+    command: ArghCommands,
+}
+
+#[derive(FromArgs, Debug, PartialEq)]
+#[argh(subcommand)]
+enum ArghCommands {
+    Tui(ArghTuiCommand),
+    #[cfg(feature = "web")]
+    Web(ArghWebCommand),
+    #[cfg(feature = "web")]
+    WebSnapshot(ArghWebSnapshotCommand),
+    TuiSnapshot(ArghTuiSnapshotCommand),
+}
+
+#[derive(FromArgs, Debug, PartialEq)]
+#[argh(subcommand, name = "tui", help_triggers("-h", "--help", "help"))]
+/// Launch the interactive terminal UI
+struct ArghTuiCommand {
+    /// schema spec: local path, file/HTTP URL, inline payload, or "-" for stdin
+    #[argh(option, short = 's')]
+    schema: Option<String>,
+
+    /// config spec: local path, file/HTTP URL, inline payload, or "-" for stdin
+    #[argh(option, short = 'c')]
+    config: Option<String>,
+
+    /// title shown at the top of the UI
+    #[argh(option)]
+    title: Option<String>,
+
+    /// output destinations ("-" writes to stdout). Repeat the flag to add more.
+    #[argh(option, short = 'o')]
+    outputs: Vec<String>,
+
+    /// write to PATH when no destinations are set (stdout remains the default)
+    #[argh(option)]
+    temp_file: Option<PathBuf>,
+
+    /// compatibility no-op: stdout is already the default when no destinations are set
+    #[argh(switch)]
+    no_temp_file: bool,
+
+    /// emit compact JSON/TOML rather than pretty formatting
+    #[argh(switch)]
+    no_pretty: bool,
+
+    /// overwrite output files even if they already exist
+    #[argh(switch, short = 'f')]
+    force: bool,
+}
+
+#[cfg(feature = "web")]
+#[derive(FromArgs, Debug, PartialEq)]
+#[argh(subcommand, name = "web", help_triggers("-h", "--help", "help"))]
+/// Launch the interactive web UI instead of the terminal UI
+struct ArghWebCommand {
+    /// schema spec: local path, file/HTTP URL, inline payload, or "-" for stdin
+    #[argh(option, short = 's')]
+    schema: Option<String>,
+
+    /// config spec: local path, file/HTTP URL, inline payload, or "-" for stdin
+    #[argh(option, short = 'c')]
+    config: Option<String>,
+
+    /// title shown at the top of the UI
+    #[argh(option)]
+    title: Option<String>,
+
+    /// output destinations ("-" writes to stdout). Repeat the flag to add more.
+    #[argh(option, short = 'o')]
+    outputs: Vec<String>,
+
+    /// write to PATH when no destinations are set (stdout remains the default)
+    #[argh(option)]
+    temp_file: Option<PathBuf>,
+
+    /// compatibility no-op: stdout is already the default when no destinations are set
+    #[argh(switch)]
+    no_temp_file: bool,
+
+    /// emit compact JSON/TOML rather than pretty formatting
+    #[argh(switch)]
+    no_pretty: bool,
+
+    /// overwrite output files even if they already exist
+    #[argh(switch, short = 'f')]
+    force: bool,
+
+    /// bind address for the temporary HTTP server
+    #[argh(option, short = 'l', default = "default_host()")]
+    host: IpAddr,
+
+    /// bind port for the temporary HTTP server (0 picks a random free port)
+    #[argh(option, short = 'p', default = "0")]
+    port: u16,
+}
+
+#[cfg(feature = "web")]
+#[derive(FromArgs, Debug, PartialEq)]
+#[argh(
+    subcommand,
+    name = "web-snapshot",
+    help_triggers("-h", "--help", "help")
+)]
+/// Precompute Web session snapshots instead of launching the UI
+struct ArghWebSnapshotCommand {
+    /// schema spec: local path, file/HTTP URL, inline payload, or "-" for stdin
+    #[argh(option, short = 's')]
+    schema: Option<String>,
+
+    /// config spec: local path, file/HTTP URL, inline payload, or "-" for stdin
+    #[argh(option, short = 'c')]
+    config: Option<String>,
+
+    /// title shown at the top of the UI
+    #[argh(option)]
+    title: Option<String>,
+
+    /// output destinations ("-" writes to stdout). Repeat the flag to add more.
+    #[argh(option, short = 'o')]
+    outputs: Vec<String>,
+
+    /// write to PATH when no destinations are set (stdout remains the default)
+    #[argh(option)]
+    temp_file: Option<PathBuf>,
+
+    /// compatibility no-op: stdout is already the default when no destinations are set
+    #[argh(switch)]
+    no_temp_file: bool,
+
+    /// emit compact JSON/TOML rather than pretty formatting
+    #[argh(switch)]
+    no_pretty: bool,
+
+    /// overwrite output files even if they already exist
+    #[argh(switch, short = 'f')]
+    force: bool,
+
+    /// output directory for generated Web snapshots (JSON + TS)
+    #[argh(option, default = "PathBuf::from(\"web_snapshots\")")]
+    out_dir: PathBuf,
+
+    /// name of the exported constant in the generated TS module
+    #[argh(option, default = "String::from(\"SessionSnapshot\")")]
+    ts_export: String,
+}
+
+#[derive(FromArgs, Debug, PartialEq)]
+#[argh(
+    subcommand,
+    name = "tui-snapshot",
+    help_triggers("-h", "--help", "help")
+)]
+/// Precompute TUI FormSchema/LayoutNavModel modules instead of launching the UI
+struct ArghTuiSnapshotCommand {
+    /// schema spec: local path, file/HTTP URL, inline payload, or "-" for stdin
+    #[argh(option, short = 's')]
+    schema: Option<String>,
+
+    /// config spec: local path, file/HTTP URL, inline payload, or "-" for stdin
+    #[argh(option, short = 'c')]
+    config: Option<String>,
+
+    /// title shown at the top of the UI
+    #[argh(option)]
+    title: Option<String>,
+
+    /// output destinations ("-" writes to stdout). Repeat the flag to add more.
+    #[argh(option, short = 'o')]
+    outputs: Vec<String>,
+
+    /// write to PATH when no destinations are set (stdout remains the default)
+    #[argh(option)]
+    temp_file: Option<PathBuf>,
+
+    /// compatibility no-op: stdout is already the default when no destinations are set
+    #[argh(switch)]
+    no_temp_file: bool,
+
+    /// emit compact JSON/TOML rather than pretty formatting
+    #[argh(switch)]
+    no_pretty: bool,
+
+    /// overwrite output files even if they already exist
+    #[argh(switch, short = 'f')]
+    force: bool,
+
+    /// output directory for generated TUI artifact modules (Rust source)
+    #[argh(option, default = "PathBuf::from(\"tui_artifacts\")")]
+    out_dir: PathBuf,
+
+    /// name of the generated TuiArtifacts constructor function
+    #[argh(option, default = "String::from(\"tui_artifacts\")")]
+    tui_fn: String,
+
+    /// name of the generated FormSchema constructor function
+    #[argh(option, default = "String::from(\"tui_form_schema\")")]
+    form_fn: String,
+
+    /// name of the generated LayoutNavModel constructor function
+    #[argh(option, default = "String::from(\"tui_layout_nav\")")]
+    layout_fn: String,
+}
+
+#[cfg(feature = "web")]
+fn default_host() -> IpAddr {
+    IpAddr::from([127, 0, 0, 1])
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommandScan {
+    None,
+    Help,
+    Explicit,
+}
+
+fn scan_for_command(args: &[String]) -> CommandScan {
+    let mut index = 0usize;
+    while index < args.len() {
+        let token = args[index].as_str();
+        if is_help_trigger(token) {
+            return CommandScan::Help;
+        }
+        if is_known_subcommand(token) {
+            return CommandScan::Explicit;
+        }
+        if consumes_multiple_values(token) {
+            index += 1;
+            while index < args.len() {
+                let next = args[index].as_str();
+                if next.starts_with('-') || is_known_subcommand(next) || is_help_trigger(next) {
+                    break;
+                }
+                index += 1;
+            }
+            continue;
+        }
+        if consumes_single_value(token) {
+            index += 2;
+            continue;
+        }
+        index += 1;
+    }
+    CommandScan::None
+}
+
+fn normalize_args(args: &[String]) -> Vec<String> {
+    let mut normalized = Vec::new();
+    for token in args {
+        if let Some((flag, value)) = normalize_inline_option(token) {
+            normalized.push(flag);
+            normalized.push(value);
+            continue;
+        }
+
+        let token = match token.as_str() {
+            "--data" => "--config",
+            "--bind" | "--listen" => "--host",
+            "-y" | "--yes" => "--force",
+            other => other,
+        };
+        normalized.push(token.to_string());
+    }
+    normalized
+}
+
+fn normalize_inline_option(token: &str) -> Option<(String, String)> {
+    const INLINE_ALIASES: &[(&str, &str)] = &[
+        ("--schema=", "--schema"),
+        ("--config=", "--config"),
+        ("--data=", "--config"),
+        ("--title=", "--title"),
+        ("--output=", "--output"),
+        ("--temp-file=", "--temp-file"),
+        ("--host=", "--host"),
+        ("--bind=", "--host"),
+        ("--listen=", "--host"),
+        ("--port=", "--port"),
+        ("--out-dir=", "--out-dir"),
+        ("--tui-fn=", "--tui-fn"),
+        ("--form-fn=", "--form-fn"),
+        ("--layout-fn=", "--layout-fn"),
+        ("--ts-export=", "--ts-export"),
+    ];
+
+    for (prefix, canonical) in INLINE_ALIASES {
+        if let Some(value) = token.strip_prefix(prefix) {
+            return Some(((*canonical).to_string(), value.to_string()));
+        }
+    }
+    None
+}
+
+fn expand_output_values(args: &[String]) -> Vec<String> {
+    let mut expanded = Vec::new();
+    let mut index = 0usize;
+    while index < args.len() {
+        let token = args[index].as_str();
+        if consumes_multiple_values(token) {
+            let canonical = "--output".to_string();
+            expanded.push(canonical.clone());
+            index += 1;
+
+            let mut consumed_any = false;
+            while index < args.len() {
+                let next = args[index].as_str();
+                if next.starts_with('-') || is_known_subcommand(next) {
+                    break;
+                }
+
+                if consumed_any {
+                    expanded.push(canonical.clone());
+                }
+                expanded.push(args[index].clone());
+                consumed_any = true;
+                index += 1;
+            }
+            continue;
+        }
+
+        expanded.push(args[index].clone());
+        index += 1;
+    }
+    expanded
+}
+
+fn consumes_single_value(token: &str) -> bool {
+    matches!(
+        token,
+        "-s" | "--schema"
+            | "-c"
+            | "--config"
+            | "--title"
+            | "--temp-file"
+            | "-l"
+            | "--host"
+            | "-p"
+            | "--port"
+            | "--out-dir"
+            | "--tui-fn"
+            | "--form-fn"
+            | "--layout-fn"
+            | "--ts-export"
+    )
+}
+
+fn consumes_multiple_values(token: &str) -> bool {
+    matches!(token, "-o" | "--output")
+}
+
+fn is_help_trigger(token: &str) -> bool {
+    matches!(token, "-h" | "--help" | "help")
+}
+
+fn is_known_subcommand(token: &str) -> bool {
+    matches!(token, "tui" | "tui-snapshot")
+        || cfg!(feature = "web") && matches!(token, "web" | "web-snapshot")
 }

--- a/schemaui-cli/src/cli.rs
+++ b/schemaui-cli/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use argh::FromArgs;
+use argh::{ArgsInfo, FromArgValue, FromArgs};
 
 #[cfg(feature = "web")]
 use std::net::IpAddr;
@@ -13,6 +13,7 @@ pub struct Cli {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Commands {
+    Completion(CompletionCommand),
     Tui(TuiCommand),
     #[cfg(feature = "web")]
     Web(WebCommand),
@@ -24,6 +25,19 @@ pub enum Commands {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TuiCommand {
     pub common: CommonArgs,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompletionCommand {
+    pub shell: CompletionShell,
+}
+
+#[derive(FromArgValue, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompletionShell {
+    Bash,
+    Zsh,
+    Fish,
+    Nushell,
 }
 
 #[cfg(feature = "web")]
@@ -141,6 +155,12 @@ impl Cli {
                 common,
                 command: None,
             },
+            ArghCommands::Completion(command) => Self {
+                common,
+                command: Some(Commands::Completion(CompletionCommand {
+                    shell: command.shell,
+                })),
+            },
             ArghCommands::Tui(command) => Self {
                 common,
                 command: Some(Commands::Tui(TuiCommand {
@@ -177,6 +197,10 @@ impl Cli {
             },
         }
     }
+}
+
+pub fn command_info() -> argh::CommandInfoWithArgs {
+    ArghCli::get_args_info()
 }
 
 fn common_args_from_root(args: &ArghCli) -> CommonArgs {
@@ -246,7 +270,7 @@ fn common_args_from_tui_snapshot(args: &ArghTuiSnapshotCommand) -> CommonArgs {
     }
 }
 
-#[derive(FromArgs, Debug, PartialEq)]
+#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
 #[argh(help_triggers("-h", "--help", "help"))]
 /// Render JSON Schemas as interactive TUIs or Web UIs
 struct ArghCli {
@@ -263,7 +287,7 @@ struct ArghCli {
     title: Option<String>,
 
     /// output destinations ("-" writes to stdout). Repeat the flag to add more.
-    #[argh(option, short = 'o')]
+    #[argh(option, short = 'o', long = "output")]
     outputs: Vec<String>,
 
     /// write to PATH when no destinations are set (stdout remains the default)
@@ -286,9 +310,10 @@ struct ArghCli {
     command: ArghCommands,
 }
 
-#[derive(FromArgs, Debug, PartialEq)]
+#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
 #[argh(subcommand)]
 enum ArghCommands {
+    Completion(ArghCompletionCommand),
     Tui(ArghTuiCommand),
     #[cfg(feature = "web")]
     Web(ArghWebCommand),
@@ -297,7 +322,16 @@ enum ArghCommands {
     TuiSnapshot(ArghTuiSnapshotCommand),
 }
 
-#[derive(FromArgs, Debug, PartialEq)]
+#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
+/// Generate shell completion scripts for the schemaui CLI
+#[argh(subcommand, name = "completion", help_triggers("-h", "--help", "help"))]
+struct ArghCompletionCommand {
+    /// target shell: bash, zsh, fish, or nushell
+    #[argh(positional)]
+    shell: CompletionShell,
+}
+
+#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
 #[argh(subcommand, name = "tui", help_triggers("-h", "--help", "help"))]
 /// Launch the interactive terminal UI
 struct ArghTuiCommand {
@@ -314,7 +348,7 @@ struct ArghTuiCommand {
     title: Option<String>,
 
     /// output destinations ("-" writes to stdout). Repeat the flag to add more.
-    #[argh(option, short = 'o')]
+    #[argh(option, short = 'o', long = "output")]
     outputs: Vec<String>,
 
     /// write to PATH when no destinations are set (stdout remains the default)
@@ -335,7 +369,7 @@ struct ArghTuiCommand {
 }
 
 #[cfg(feature = "web")]
-#[derive(FromArgs, Debug, PartialEq)]
+#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
 #[argh(subcommand, name = "web", help_triggers("-h", "--help", "help"))]
 /// Launch the interactive web UI instead of the terminal UI
 struct ArghWebCommand {
@@ -352,7 +386,7 @@ struct ArghWebCommand {
     title: Option<String>,
 
     /// output destinations ("-" writes to stdout). Repeat the flag to add more.
-    #[argh(option, short = 'o')]
+    #[argh(option, short = 'o', long = "output")]
     outputs: Vec<String>,
 
     /// write to PATH when no destinations are set (stdout remains the default)
@@ -381,7 +415,7 @@ struct ArghWebCommand {
 }
 
 #[cfg(feature = "web")]
-#[derive(FromArgs, Debug, PartialEq)]
+#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
 #[argh(
     subcommand,
     name = "web-snapshot",
@@ -402,7 +436,7 @@ struct ArghWebSnapshotCommand {
     title: Option<String>,
 
     /// output destinations ("-" writes to stdout). Repeat the flag to add more.
-    #[argh(option, short = 'o')]
+    #[argh(option, short = 'o', long = "output")]
     outputs: Vec<String>,
 
     /// write to PATH when no destinations are set (stdout remains the default)
@@ -430,7 +464,7 @@ struct ArghWebSnapshotCommand {
     ts_export: String,
 }
 
-#[derive(FromArgs, Debug, PartialEq)]
+#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
 #[argh(
     subcommand,
     name = "tui-snapshot",
@@ -451,7 +485,7 @@ struct ArghTuiSnapshotCommand {
     title: Option<String>,
 
     /// output destinations ("-" writes to stdout). Repeat the flag to add more.
-    #[argh(option, short = 'o')]
+    #[argh(option, short = 'o', long = "output")]
     outputs: Vec<String>,
 
     /// write to PATH when no destinations are set (stdout remains the default)
@@ -531,22 +565,73 @@ fn scan_for_command(args: &[String]) -> CommandScan {
 
 fn normalize_args(args: &[String]) -> Vec<String> {
     let mut normalized = Vec::new();
-    for token in args {
+    let mut index = 0usize;
+    let mut segment_start = 0usize;
+
+    while index < args.len() {
+        let token = args[index].as_str();
+
         if let Some((flag, value)) = normalize_inline_option(token) {
-            normalized.push(flag);
-            normalized.push(value);
+            if consumes_single_value(&flag) {
+                upsert_single_value_option(&mut normalized, segment_start, flag, value);
+            } else {
+                normalized.push(flag);
+                normalized.push(value);
+            }
+            index += 1;
             continue;
         }
 
-        let token = match token.as_str() {
+        let token = match token {
             "--data" => "--config",
             "--bind" | "--listen" => "--host",
             "-y" | "--yes" => "--force",
             other => other,
         };
+
+        if is_known_subcommand(token) {
+            normalized.push(token.to_string());
+            segment_start = normalized.len();
+            index += 1;
+            continue;
+        }
+
+        if consumes_single_value(token)
+            && let Some(value) = args.get(index + 1)
+        {
+            upsert_single_value_option(
+                &mut normalized,
+                segment_start,
+                token.to_string(),
+                value.clone(),
+            );
+            index += 2;
+            continue;
+        }
+
         normalized.push(token.to_string());
+        index += 1;
     }
+
     normalized
+}
+
+fn upsert_single_value_option(
+    normalized: &mut Vec<String>,
+    segment_start: usize,
+    flag: String,
+    value: String,
+) {
+    if let Some(position) = normalized[segment_start..]
+        .windows(2)
+        .position(|window| window[0] == flag)
+    {
+        normalized[segment_start + position + 1] = value;
+        return;
+    }
+
+    normalized.push(flag);
+    normalized.push(value);
 }
 
 fn normalize_inline_option(token: &str) -> Option<(String, String)> {
@@ -638,6 +723,6 @@ fn is_help_trigger(token: &str) -> bool {
 }
 
 fn is_known_subcommand(token: &str) -> bool {
-    matches!(token, "tui" | "tui-snapshot")
+    matches!(token, "completion" | "tui" | "tui-snapshot")
         || cfg!(feature = "web") && matches!(token, "web" | "web-snapshot")
 }

--- a/schemaui-cli/src/cli.rs
+++ b/schemaui-cli/src/cli.rs
@@ -110,11 +110,11 @@ pub struct TuiSnapshotCommand {
 
 #[derive(Debug, Args, Clone)]
 pub struct CommonArgs {
-    /// Schema spec: file path, inline payload, or "-" for stdin
+    /// Schema spec: local path, file/HTTP URL, inline payload, or "-" for stdin
     #[arg(short = 's', long = "schema", value_name = "SPEC")]
     pub schema: Option<String>,
 
-    /// Config spec: file path, inline payload, or "-" for stdin
+    /// Config spec: local path, file/HTTP URL, inline payload, or "-" for stdin
     #[arg(short = 'c', long = "config", alias = "data", value_name = "SPEC")]
     pub config: Option<String>,
 
@@ -126,12 +126,12 @@ pub struct CommonArgs {
     #[arg(short = 'o', long = "output", value_name = "DEST", num_args = 1.., action = ArgAction::Append)]
     pub outputs: Vec<String>,
 
-    /// Override the default temp file location (only used when no other destinations are set)
+    /// Write to PATH when no destinations are set (stdout remains the default)
     #[arg(long = "temp-file", value_name = "PATH")]
     pub temp_file: Option<PathBuf>,
 
-    /// Disable writing to the default temp file when no destinations are provided
-    #[arg(long = "no-temp-file")]
+    /// Compatibility no-op: stdout is already the default when no destinations are set
+    #[arg(long = "no-temp-file", conflicts_with = "temp_file")]
     pub no_temp_file: bool,
 
     /// Emit compact JSON/TOML rather than pretty formatting

--- a/schemaui-cli/src/completion.rs
+++ b/schemaui-cli/src/completion.rs
@@ -1,0 +1,35 @@
+use std::path::Path;
+
+use argh_complete::Generator;
+use color_eyre::eyre::Result;
+
+use crate::cli::{CompletionCommand, CompletionShell, command_info};
+
+pub fn render_script(shell: CompletionShell) -> String {
+    let command_name = command_name();
+    let info = command_info();
+
+    match shell {
+        CompletionShell::Bash => argh_complete::bash::Bash::generate(&command_name, &info),
+        CompletionShell::Zsh => argh_complete::zsh::Zsh::generate(&command_name, &info),
+        CompletionShell::Fish => argh_complete::fish::Fish::generate(&command_name, &info),
+        CompletionShell::Nushell => argh_complete::nushell::Nushell::generate(&command_name, &info),
+    }
+}
+
+pub fn run_cli(args: CompletionCommand) -> Result<()> {
+    print!("{}", render_script(args.shell));
+    Ok(())
+}
+
+fn command_name() -> String {
+    std::env::args()
+        .next()
+        .and_then(|arg0| {
+            Path::new(&arg0)
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+        })
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "schemaui".to_string())
+}

--- a/schemaui-cli/src/io.rs
+++ b/schemaui-cli/src/io.rs
@@ -59,7 +59,7 @@ fn parse_contents(contents: &str, format: DocumentFormat, label: &str) -> Result
             }
             Err(Report::msg(format!(
                 "failed to parse {label}: tried {} (first error: {primary})",
-                format_list()
+                DocumentFormat::format_list()
             )))
         }
     }
@@ -68,23 +68,4 @@ fn parse_contents(contents: &str, format: DocumentFormat, label: &str) -> Result
 pub fn is_not_found(err: &Report) -> bool {
     err.downcast_ref::<io::Error>()
         .is_some_and(|io_err| io_err.kind() == io::ErrorKind::NotFound)
-}
-
-fn format_list() -> &'static str {
-    #[cfg(all(feature = "yaml", feature = "toml"))]
-    {
-        "JSON/YAML/TOML"
-    }
-    #[cfg(all(feature = "yaml", not(feature = "toml")))]
-    {
-        "JSON/YAML"
-    }
-    #[cfg(all(not(feature = "yaml"), feature = "toml"))]
-    {
-        "JSON/TOML"
-    }
-    #[cfg(all(not(feature = "yaml"), not(feature = "toml")))]
-    {
-        "JSON"
-    }
 }

--- a/schemaui-cli/src/lib.rs
+++ b/schemaui-cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod completion;
 pub mod io;
 pub mod session;
 pub mod tui;

--- a/schemaui-cli/src/main.rs
+++ b/schemaui-cli/src/main.rs
@@ -1,25 +1,43 @@
 #![doc = include_str!("../cli_usage.md")]
 
-use clap::Parser;
 use color_eyre::eyre::Result;
 
-use schemaui_cli::cli::{Cli, Commands};
+use schemaui_cli::cli::{Cli, Commands, TuiSnapshotCommand};
 use schemaui_cli::tui;
 
+#[cfg(feature = "web")]
+use schemaui_cli::cli::{WebCommand, WebSnapshotCommand};
 #[cfg(feature = "web")]
 use schemaui_cli::web;
 
 fn main() -> Result<()> {
     color_eyre::install()?;
-    let cli = Cli::parse();
+    let Cli { common, command } = Cli::from_env_or_exit();
 
-    match cli.command {
-        Some(Commands::Tui(args)) => tui::run_cli(&args.common),
-        None => tui::run_cli(&cli.common),
-        Some(Commands::TuiSnapshot(args)) => tui::run_snapshot_cli(args),
+    match command {
+        Some(Commands::Tui(args)) => {
+            let common = common.merged_with(&args.common);
+            tui::run_cli(&common)
+        }
+        None => tui::run_cli(&common),
+        Some(Commands::TuiSnapshot(args)) => tui::run_snapshot_cli(TuiSnapshotCommand {
+            common: common.merged_with(&args.common),
+            out_dir: args.out_dir,
+            tui_fn: args.tui_fn,
+            form_fn: args.form_fn,
+            layout_fn: args.layout_fn,
+        }),
         #[cfg(feature = "web")]
-        Some(Commands::Web(args)) => web::run_cli(args),
+        Some(Commands::Web(args)) => web::run_cli(WebCommand {
+            common: common.merged_with(&args.common),
+            host: args.host,
+            port: args.port,
+        }),
         #[cfg(feature = "web")]
-        Some(Commands::WebSnapshot(args)) => web::run_snapshot_cli(args),
+        Some(Commands::WebSnapshot(args)) => web::run_snapshot_cli(WebSnapshotCommand {
+            common: common.merged_with(&args.common),
+            out_dir: args.out_dir,
+            ts_export: args.ts_export,
+        }),
     }
 }

--- a/schemaui-cli/src/main.rs
+++ b/schemaui-cli/src/main.rs
@@ -3,6 +3,7 @@
 use color_eyre::eyre::Result;
 
 use schemaui_cli::cli::{Cli, Commands, TuiSnapshotCommand};
+use schemaui_cli::completion;
 use schemaui_cli::tui;
 
 #[cfg(feature = "web")]
@@ -15,6 +16,7 @@ fn main() -> Result<()> {
     let Cli { common, command } = Cli::from_env_or_exit();
 
     match command {
+        Some(Commands::Completion(args)) => completion::run_cli(args),
         Some(Commands::Tui(args)) => {
             let common = common.merged_with(&args.common);
             tui::run_cli(&common)

--- a/schemaui-cli/src/session/builder.rs
+++ b/schemaui-cli/src/session/builder.rs
@@ -1,14 +1,12 @@
 use color_eyre::eyre::{Result, eyre};
-use schemaui::{DocumentFormat, schema_from_data_value};
-use serde_json::Value;
 
 use crate::cli::CommonArgs;
-use crate::io::load_value;
 
 use super::bundle::SessionBundle;
 use super::diagnostics::DiagnosticCollector;
 use super::format::resolve_format_hint;
 use super::output::{build_output_options, ensure_output_paths_available};
+use super::schema_source::{load_optional_document, resolve_session_inputs};
 
 pub fn prepare_session(args: &CommonArgs) -> Result<SessionBundle> {
     let mut diagnostics = DiagnosticCollector::default();
@@ -27,14 +25,14 @@ pub fn prepare_session(args: &CommonArgs) -> Result<SessionBundle> {
     let schema_hint = resolve_format_hint(schema_spec, "schema", &mut diagnostics);
     let config_hint = resolve_format_hint(config_spec, "config", &mut diagnostics);
 
-    let schema_value = load_optional_value(
+    let schema_document = load_optional_document(
         schema_spec,
         schema_hint.hint.format,
         "schema",
         schema_hint.blocked || (schema_stdin && config_stdin),
         &mut diagnostics,
     );
-    let config_value = load_optional_value(
+    let config_document = load_optional_document(
         config_spec,
         config_hint.hint.format,
         "config",
@@ -52,95 +50,15 @@ pub fn prepare_session(args: &CommonArgs) -> Result<SessionBundle> {
 
     diagnostics.into_result()?;
 
-    let mut schema_value = schema_value;
-    let mut config_value = config_value;
-    if schema_value.is_none()
-        && let Some(config_doc) = config_value.as_ref()
-        && looks_like_json_schema(config_doc)
-    {
-        eprintln!("detected JSON Schema provided via --config; treating it as the active schema");
-        schema_value = config_value.take();
-    }
-
-    if schema_value.is_none() && config_value.is_none() {
+    if schema_document.is_none() && config_document.is_none() {
         return Err(eyre!("provide at least --schema or --config"));
     }
-
-    let schema = match (schema_value, config_value.as_ref()) {
-        (Some(schema), _) => schema,
-        (None, Some(defaults)) => schema_from_data_value(defaults),
-        (None, None) => unreachable!("validated above"),
-    };
+    let resolved = resolve_session_inputs(schema_document, config_document)?;
 
     Ok(SessionBundle {
-        schema,
-        defaults: config_value,
+        schema: resolved.schema,
+        defaults: resolved.defaults,
         title: args.title.clone(),
         output: output_settings,
     })
-}
-
-fn load_optional_value(
-    spec: Option<&str>,
-    format: DocumentFormat,
-    label: &str,
-    skip: bool,
-    diagnostics: &mut DiagnosticCollector,
-) -> Option<Value> {
-    if skip {
-        return None;
-    }
-    let raw = spec?;
-    match load_value(raw, format, label) {
-        Ok(value) => Some(value),
-        Err(err) => {
-            diagnostics.push_input(label, err.to_string());
-            None
-        }
-    }
-}
-
-fn looks_like_json_schema(value: &Value) -> bool {
-    let obj = match value.as_object() {
-        Some(map) => map,
-        None => return false,
-    };
-
-    if obj
-        .get("properties")
-        .and_then(Value::as_object)
-        .map(|props| props.len())
-        .unwrap_or(0)
-        == 0
-    {
-        return false;
-    }
-
-    if obj.contains_key("$schema") {
-        return true;
-    }
-
-    if matches!(obj.get("type"), Some(Value::String(t)) if t == "object") {
-        return true;
-    }
-
-    if let Some(props) = obj.get("properties").and_then(Value::as_object) {
-        let mut scored = 0usize;
-
-        for value in props.values() {
-            if value.get("type").is_some() {
-                scored += 1;
-            }
-            if value.get("properties").is_some() {
-                scored += 1;
-            }
-            if value.get("enum").is_some() {
-                scored += 1;
-            }
-        }
-
-        return scored >= 2;
-    }
-
-    false
 }

--- a/schemaui-cli/src/session/format.rs
+++ b/schemaui-cli/src/session/format.rs
@@ -4,6 +4,8 @@ use schemaui::DocumentFormat;
 
 use super::diagnostics::DiagnosticCollector;
 
+pub use schemaui::DocumentFormatProbe as ExtensionFormat;
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct FormatHint {
     pub format: DocumentFormat,
@@ -65,38 +67,6 @@ pub fn resolve_format_hint(
     }
 }
 
-#[derive(Debug)]
-pub enum ExtensionFormat {
-    Known(DocumentFormat),
-    #[allow(dead_code)]
-    UnsupportedFeature {
-        format_name: &'static str,
-        feature_flag: &'static str,
-    },
-    Unknown,
-}
-
 pub fn probe_format_from_extension(path: &Path) -> ExtensionFormat {
-    let Some(ext) = path.extension() else {
-        return ExtensionFormat::Unknown;
-    };
-    let normalized = ext.to_string_lossy().to_ascii_lowercase();
-    match normalized.as_str() {
-        "json" => ExtensionFormat::Known(DocumentFormat::Json),
-        #[cfg(feature = "yaml")]
-        "yaml" | "yml" => ExtensionFormat::Known(DocumentFormat::Yaml),
-        #[cfg(not(feature = "yaml"))]
-        "yaml" | "yml" => ExtensionFormat::UnsupportedFeature {
-            format_name: "yaml",
-            feature_flag: "yaml",
-        },
-        #[cfg(feature = "toml")]
-        "toml" => ExtensionFormat::Known(DocumentFormat::Toml),
-        #[cfg(not(feature = "toml"))]
-        "toml" => ExtensionFormat::UnsupportedFeature {
-            format_name: "toml",
-            feature_flag: "toml",
-        },
-        _ => ExtensionFormat::Unknown,
-    }
+    DocumentFormat::probe_extension(path)
 }

--- a/schemaui-cli/src/session/mod.rs
+++ b/schemaui-cli/src/session/mod.rs
@@ -1,10 +1,9 @@
 mod builder;
 mod bundle;
-mod diagnostics;
-mod format;
+pub(crate) mod diagnostics;
+pub(crate) mod format;
 mod output;
+pub(crate) mod schema_source;
 
 pub use builder::prepare_session;
 pub use bundle::SessionBundle;
-
-const DEFAULT_TEMP_FILE: &str = "/tmp/schemaui.json";

--- a/schemaui-cli/src/session/output.rs
+++ b/schemaui-cli/src/session/output.rs
@@ -4,7 +4,6 @@ use schemaui::{DocumentFormat, OutputDestination, OutputOptions};
 
 use crate::cli::CommonArgs;
 
-use super::DEFAULT_TEMP_FILE;
 use super::diagnostics::DiagnosticCollector;
 use super::format::{ExtensionFormat, probe_format_from_extension};
 
@@ -30,14 +29,11 @@ pub fn build_output_options(
     }
 
     if destinations.is_empty() && !explicit_outputs {
-        if args.no_temp_file {
-            return (None, Vec::new());
+        if let Some(path) = args.temp_file.clone() {
+            destinations.push(OutputDestination::file(path));
+        } else {
+            destinations.push(OutputDestination::Stdout);
         }
-        let fallback = args
-            .temp_file
-            .clone()
-            .unwrap_or_else(|| PathBuf::from(DEFAULT_TEMP_FILE));
-        destinations.push(OutputDestination::file(fallback.clone()));
     }
 
     if destinations.is_empty() {

--- a/schemaui-cli/src/session/schema_source.rs
+++ b/schemaui-cli/src/session/schema_source.rs
@@ -1,0 +1,507 @@
+use std::env;
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+#[cfg(feature = "remote-schema")]
+use std::time::Duration;
+
+use color_eyre::eyre::{Report, Result, WrapErr, eyre};
+#[cfg(feature = "remote-schema")]
+use reqwest::blocking::Client;
+use schemaui::{DocumentFormat, DocumentFormatProbe, parse_document_str, schema_from_data_value};
+use serde_json::Value;
+use url::Url;
+
+use super::diagnostics::DiagnosticCollector;
+
+#[derive(Debug, Clone)]
+pub(crate) enum DocumentOrigin {
+    File(PathBuf),
+    #[cfg(feature = "remote-schema")]
+    Url(Url),
+    Inline,
+    Stdin,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LoadedDocument {
+    pub value: Value,
+    #[cfg(any(feature = "yaml", feature = "toml"))]
+    pub raw: String,
+    pub format: DocumentFormat,
+    pub origin: DocumentOrigin,
+}
+
+#[derive(Debug)]
+pub(crate) struct ResolvedSessionInputs {
+    pub schema: Value,
+    pub defaults: Option<Value>,
+}
+
+pub(crate) fn load_optional_document(
+    spec: Option<&str>,
+    format: DocumentFormat,
+    label: &str,
+    skip: bool,
+    diagnostics: &mut DiagnosticCollector,
+) -> Option<LoadedDocument> {
+    if skip {
+        return None;
+    }
+    let spec = spec?;
+    match load_document(spec, format, label) {
+        Ok(document) => Some(document),
+        Err(err) => {
+            diagnostics.push_input(label, err.to_string());
+            None
+        }
+    }
+}
+
+pub(crate) fn load_document(
+    spec: &str,
+    format: DocumentFormat,
+    label: &str,
+) -> Result<LoadedDocument> {
+    if spec == "-" {
+        let raw = read_stdin()?;
+        let value = parse_contents(&raw, format, label)?;
+        return Ok(LoadedDocument {
+            value,
+            #[cfg(any(feature = "yaml", feature = "toml"))]
+            raw,
+            format,
+            origin: DocumentOrigin::Stdin,
+        });
+    }
+
+    if let Some(url) = parse_special_url(spec) {
+        return load_document_from_url(url, format, label);
+    }
+
+    let path = PathBuf::from(spec);
+    match fs::read_to_string(&path) {
+        Ok(raw) => {
+            let value = parse_contents(&raw, format, label)?;
+            Ok(LoadedDocument {
+                value,
+                #[cfg(any(feature = "yaml", feature = "toml"))]
+                raw,
+                format,
+                origin: DocumentOrigin::File(path),
+            })
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            let inline_label = format!("inline {label}");
+            let value = parse_contents(spec, format, &inline_label)?;
+            Ok(LoadedDocument {
+                value,
+                #[cfg(any(feature = "yaml", feature = "toml"))]
+                raw: spec.to_string(),
+                format,
+                origin: DocumentOrigin::Inline,
+            })
+        }
+        Err(err) => {
+            Err(Report::new(err)
+                .wrap_err(format!("failed to load {label} from {}", path.display())))
+        }
+    }
+}
+
+pub(crate) fn resolve_session_inputs(
+    explicit_schema: Option<LoadedDocument>,
+    config: Option<LoadedDocument>,
+) -> Result<ResolvedSessionInputs> {
+    let explicit_schema = explicit_schema.map(|document| document.value);
+
+    if explicit_schema.is_none()
+        && let Some(config) = config.as_ref()
+        && looks_like_json_schema(&config.value)
+    {
+        eprintln!("detected JSON Schema provided via --config; treating it as the active schema");
+        return Ok(ResolvedSessionInputs {
+            schema: config.value.clone(),
+            defaults: None,
+        });
+    }
+
+    let config = config.map(PreparedConfig::from_loaded).transpose()?;
+
+    let schema = if let Some(schema) = explicit_schema {
+        schema
+    } else if let Some(reference) = config
+        .as_ref()
+        .and_then(|config| config.declared_schema.as_deref())
+    {
+        load_schema_reference(reference, config.as_ref().map(|config| &config.origin))?
+    } else if let Some(config) = config.as_ref() {
+        schema_from_data_value(&config.value)
+    } else {
+        return Err(eyre!("provide at least --schema or --config"));
+    };
+
+    Ok(ResolvedSessionInputs {
+        schema,
+        defaults: config.map(|config| config.value),
+    })
+}
+
+#[derive(Debug)]
+struct PreparedConfig {
+    value: Value,
+    declared_schema: Option<String>,
+    origin: DocumentOrigin,
+}
+
+impl PreparedConfig {
+    fn from_loaded(document: LoadedDocument) -> Result<Self> {
+        let declared_schema = detect_declared_schema(&document);
+        let value = match document.format {
+            #[cfg(feature = "json")]
+            DocumentFormat::Json if declared_schema.is_some() => {
+                strip_root_json_schema_declaration(document.value)
+            }
+            _ => document.value,
+        };
+
+        Ok(Self {
+            value,
+            declared_schema,
+            origin: document.origin,
+        })
+    }
+}
+
+fn load_schema_reference(reference: &str, base: Option<&DocumentOrigin>) -> Result<Value> {
+    let location = resolve_schema_reference(reference, base)?;
+    let format = format_for_reference_location(&location)?;
+    match location {
+        ReferenceLocation::File(path) => {
+            let raw = fs::read_to_string(&path)
+                .wrap_err_with(|| format!("failed to read schema file {}", path.display()))?;
+            parse_contents(&raw, format, "schema")
+        }
+        ReferenceLocation::Url(url) => {
+            let document = load_document_from_url(url, format, "schema")?;
+            Ok(document.value)
+        }
+    }
+}
+
+fn resolve_schema_reference(
+    reference: &str,
+    base: Option<&DocumentOrigin>,
+) -> Result<ReferenceLocation> {
+    if let Some(url) = parse_special_url(reference) {
+        return match url.scheme() {
+            "file" => {
+                let path = url
+                    .to_file_path()
+                    .map_err(|_| eyre!("invalid file:// schema reference: {url}"))?;
+                Ok(ReferenceLocation::File(path))
+            }
+            _ => Ok(ReferenceLocation::Url(url)),
+        };
+    }
+
+    let reference_path = PathBuf::from(reference);
+    if reference_path.is_absolute() {
+        return Ok(ReferenceLocation::File(reference_path));
+    }
+
+    match base {
+        Some(DocumentOrigin::File(path)) => {
+            let parent = path.parent().unwrap_or_else(|| Path::new("."));
+            Ok(ReferenceLocation::File(parent.join(reference_path)))
+        }
+        #[cfg(feature = "remote-schema")]
+        Some(DocumentOrigin::Url(url)) => {
+            let joined = url
+                .join(reference)
+                .wrap_err_with(|| format!("failed to resolve schema reference '{reference}'"))?;
+            if joined.scheme() == "file" {
+                let path = joined
+                    .to_file_path()
+                    .map_err(|_| eyre!("invalid file:// schema reference: {joined}"))?;
+                Ok(ReferenceLocation::File(path))
+            } else {
+                Ok(ReferenceLocation::Url(joined))
+            }
+        }
+        Some(DocumentOrigin::Inline) | Some(DocumentOrigin::Stdin) | None => {
+            let cwd = env::current_dir().wrap_err("failed to resolve current working directory")?;
+            Ok(ReferenceLocation::File(cwd.join(reference_path)))
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ReferenceLocation {
+    File(PathBuf),
+    Url(Url),
+}
+
+fn format_for_reference_location(location: &ReferenceLocation) -> Result<DocumentFormat> {
+    let probe = match location {
+        ReferenceLocation::File(path) => DocumentFormat::probe_extension(path),
+        ReferenceLocation::Url(url) => DocumentFormat::probe_extension(Path::new(url.path())),
+    };
+
+    match probe {
+        DocumentFormatProbe::Known(format) => Ok(format),
+        DocumentFormatProbe::UnsupportedFeature {
+            format_name,
+            feature_flag,
+        } => Err(eyre!(
+            "schema reference {} requires {format_name} support, but this build lacks the '{feature_flag}' feature",
+            reference_location_label(location)
+        )),
+        DocumentFormatProbe::Unknown => Ok(DocumentFormat::default()),
+    }
+}
+
+fn detect_declared_schema(document: &LoadedDocument) -> Option<String> {
+    match document.format {
+        #[cfg(feature = "json")]
+        DocumentFormat::Json => document
+            .value
+            .as_object()
+            .and_then(|object| object.get("$schema"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        #[cfg(feature = "yaml")]
+        DocumentFormat::Yaml => detect_yaml_schema_directive(&document.raw),
+        #[cfg(feature = "toml")]
+        DocumentFormat::Toml => detect_toml_schema_directive(&document.raw),
+    }
+}
+
+#[cfg(feature = "yaml")]
+fn detect_yaml_schema_directive(raw: &str) -> Option<String> {
+    for (index, line) in raw.lines().enumerate() {
+        let trimmed = if index == 0 {
+            line.trim_start_matches('\u{feff}').trim()
+        } else {
+            line.trim()
+        };
+
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some(comment) = trimmed.strip_prefix('#') else {
+            break;
+        };
+        let comment = comment.trim();
+
+        if let Some(rest) = comment.strip_prefix("yaml-language-server:") {
+            let rest = rest.trim();
+            if let Some(rest) = rest.strip_prefix("$schema") {
+                let rest = rest.trim_start();
+                let rest = rest.strip_prefix('=')?.trim();
+                if !rest.is_empty() {
+                    return Some(rest.to_string());
+                }
+            }
+        }
+
+        if let Some(rest) = comment.strip_prefix("@schema") {
+            let rest = rest.trim();
+            if !rest.is_empty() {
+                return Some(rest.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(feature = "toml")]
+fn detect_toml_schema_directive(raw: &str) -> Option<String> {
+    for (index, line) in raw.lines().enumerate() {
+        let trimmed = if index == 0 {
+            line.trim_start_matches('\u{feff}').trim()
+        } else {
+            line.trim()
+        };
+
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if let Some(rest) = trimmed.strip_prefix("#:schema") {
+            let rest = rest.trim();
+            if !rest.is_empty() {
+                return Some(rest.to_string());
+            }
+        }
+
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        break;
+    }
+    None
+}
+
+fn strip_root_json_schema_declaration(value: Value) -> Value {
+    match value {
+        Value::Object(mut object) => {
+            object.remove("$schema");
+            Value::Object(object)
+        }
+        other => other,
+    }
+}
+
+fn load_document_from_url(url: Url, format: DocumentFormat, label: &str) -> Result<LoadedDocument> {
+    match url.scheme() {
+        "file" => {
+            let path = url
+                .to_file_path()
+                .map_err(|_| eyre!("invalid file:// URL for {label}: {url}"))?;
+            let raw = fs::read_to_string(&path)
+                .wrap_err_with(|| format!("failed to read {label} file {}", path.display()))?;
+            let value = parse_contents(&raw, format, label)?;
+            Ok(LoadedDocument {
+                value,
+                #[cfg(any(feature = "yaml", feature = "toml"))]
+                raw,
+                format,
+                origin: DocumentOrigin::File(path),
+            })
+        }
+        #[cfg(feature = "remote-schema")]
+        "http" | "https" => {
+            let mut client = Client::builder().timeout(Duration::from_secs(15));
+            if should_bypass_proxy(&url) {
+                client = client.no_proxy();
+            }
+            let client = client
+                .build()
+                .wrap_err("failed to initialize HTTP client")?;
+            let response = client
+                .get(url.clone())
+                .send()
+                .wrap_err_with(|| format!("failed to fetch {label} from {url}"))?;
+            let status = response.status();
+            if !status.is_success() {
+                return Err(eyre!(
+                    "failed to fetch {label} from {url}: HTTP {}",
+                    status.as_u16()
+                ));
+            }
+            let raw = response
+                .text()
+                .wrap_err_with(|| format!("failed to read {label} response body from {url}"))?;
+            let value = parse_contents(&raw, format, label)?;
+            Ok(LoadedDocument {
+                value,
+                #[cfg(any(feature = "yaml", feature = "toml"))]
+                raw,
+                format,
+                #[cfg(feature = "remote-schema")]
+                origin: DocumentOrigin::Url(url),
+                #[cfg(not(feature = "remote-schema"))]
+                origin: DocumentOrigin::Inline,
+            })
+        }
+        #[cfg(not(feature = "remote-schema"))]
+        "http" | "https" => Err(eyre!(
+            "remote schema support is disabled in this build; re-enable the 'remote-schema' feature to load {label} from {url}"
+        )),
+        _ => Err(eyre!("unsupported URL scheme for {label}: {url}")),
+    }
+}
+
+fn parse_special_url(spec: &str) -> Option<Url> {
+    let url = Url::parse(spec).ok()?;
+    match url.scheme() {
+        "http" | "https" | "file" => Some(url),
+        _ => None,
+    }
+}
+
+#[cfg(feature = "remote-schema")]
+fn should_bypass_proxy(url: &Url) -> bool {
+    matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "::1"))
+}
+
+fn read_stdin() -> Result<String> {
+    let mut buffer = String::new();
+    io::stdin()
+        .read_to_string(&mut buffer)
+        .wrap_err("failed to read from stdin")?;
+    Ok(buffer)
+}
+
+fn parse_contents(contents: &str, format: DocumentFormat, label: &str) -> Result<Value> {
+    match parse_document_str(contents, format) {
+        Ok(value) => Ok(value),
+        Err(primary) => {
+            for candidate in DocumentFormat::available_formats() {
+                if candidate == format {
+                    continue;
+                }
+                if let Ok(value) = parse_document_str(contents, candidate) {
+                    return Ok(value);
+                }
+            }
+            Err(eyre!(
+                "failed to parse {label}: tried {} (first error: {primary})",
+                DocumentFormat::format_list()
+            ))
+        }
+    }
+}
+
+fn reference_location_label(location: &ReferenceLocation) -> String {
+    match location {
+        ReferenceLocation::File(path) => path.display().to_string(),
+        ReferenceLocation::Url(url) => url.to_string(),
+    }
+}
+
+fn looks_like_json_schema(value: &Value) -> bool {
+    let obj = match value.as_object() {
+        Some(map) => map,
+        None => return false,
+    };
+
+    if obj
+        .get("properties")
+        .and_then(Value::as_object)
+        .map(|props| props.len())
+        .unwrap_or(0)
+        == 0
+    {
+        return false;
+    }
+
+    if obj.contains_key("$schema") {
+        return true;
+    }
+
+    if matches!(obj.get("type"), Some(Value::String(t)) if t == "object") {
+        return true;
+    }
+
+    if let Some(props) = obj.get("properties").and_then(Value::as_object) {
+        let mut scored = 0usize;
+
+        for value in props.values() {
+            if value.get("type").is_some() {
+                scored += 1;
+            }
+            if value.get("properties").is_some() {
+                scored += 1;
+            }
+            if value.get("enum").is_some() {
+                scored += 1;
+            }
+        }
+
+        return scored >= 2;
+    }
+
+    false
+}

--- a/schemaui-cli/src/tui/mod.rs
+++ b/schemaui-cli/src/tui/mod.rs
@@ -1,11 +1,13 @@
 use std::fs;
-use std::path::PathBuf;
 
 use color_eyre::eyre::{Report, Result};
+use schemaui::SchemaUI;
 use schemaui::precompile::tui as pre_tui;
-use schemaui::{DocumentFormat, SchemaUI};
 
 use crate::cli::{CommonArgs, TuiSnapshotCommand};
+use crate::session::diagnostics::DiagnosticCollector;
+use crate::session::format::resolve_format_hint;
+use crate::session::schema_source::{load_optional_document, resolve_session_inputs};
 use crate::session::{SessionBundle, prepare_session};
 
 pub fn run_cli(args: &CommonArgs) -> Result<()> {
@@ -34,70 +36,58 @@ pub(crate) fn execute_session(session: SessionBundle) -> Result<()> {
 }
 
 pub fn run_snapshot_cli(cmd: TuiSnapshotCommand) -> Result<()> {
-    // For TUI snapshots we require a schema file path (no stdin/inline).
-    let schema_spec = cmd
-        .common
-        .schema
-        .as_deref()
-        .ok_or_else(|| Report::msg("tui-snapshot requires --schema <PATH>"))?;
-    if schema_spec == "-" {
-        return Err(Report::msg(
-            "tui-snapshot does not support --schema - (stdin); please pass a file path",
-        ));
-    }
-
-    let schema_path = PathBuf::from(schema_spec);
-    if !schema_path.exists() {
-        return Err(Report::msg(format!(
-            "schema path {:?} does not exist",
-            schema_path
-        )));
-    }
-
+    let schema_spec = cmd.common.schema.as_deref();
     let config_spec = cmd.common.config.as_deref();
-    if config_spec == Some("-") {
-        return Err(Report::msg(
-            "tui-snapshot does not support --config - (stdin); please pass a file path",
-        ));
+    let mut diagnostics = DiagnosticCollector::default();
+    let schema_stdin = schema_spec == Some("-");
+    let config_stdin = config_spec == Some("-");
+    if schema_stdin && config_stdin {
+        diagnostics.push_input(
+            "schema/config",
+            "cannot read schema and config from stdin simultaneously; provide inline content, files, or a remote schema",
+        );
     }
-
-    let defaults_path = config_spec.map(PathBuf::from);
-    if let Some(ref path) = defaults_path
-        && !path.exists()
-    {
-        return Err(Report::msg(format!(
-            "config path {:?} does not exist",
-            path
-        )));
-    }
-
-    let format = DocumentFormat::from_extension(&schema_path).unwrap_or(DocumentFormat::Json);
+    let schema_hint = resolve_format_hint(schema_spec, "schema", &mut diagnostics);
+    let config_hint = resolve_format_hint(config_spec, "config", &mut diagnostics);
+    let schema_document = load_optional_document(
+        schema_spec,
+        schema_hint.hint.format,
+        "schema",
+        schema_hint.blocked || (schema_stdin && config_stdin),
+        &mut diagnostics,
+    );
+    let config_document = load_optional_document(
+        config_spec,
+        config_hint.hint.format,
+        "config",
+        config_hint.blocked || (schema_stdin && config_stdin),
+        &mut diagnostics,
+    );
+    diagnostics.into_result()?;
+    let resolved = resolve_session_inputs(schema_document, config_document).map_err(Report::msg)?;
 
     fs::create_dir_all(&cmd.out_dir)?;
     let tui_module = cmd.out_dir.join("tui_artifacts.rs");
     let form_module = cmd.out_dir.join("tui_form_schema.rs");
     let layout_module = cmd.out_dir.join("tui_layout_nav.rs");
 
-    pre_tui::generate_tui_artifacts_module(
-        &schema_path,
-        format,
-        defaults_path.as_deref(),
+    pre_tui::generate_tui_artifacts_module_from_value(
+        &resolved.schema,
+        resolved.defaults.as_ref(),
         &tui_module,
         &cmd.tui_fn,
     )
     .map_err(Report::msg)?;
-    pre_tui::generate_tui_form_schema_module(
-        &schema_path,
-        format,
-        defaults_path.as_deref(),
+    pre_tui::generate_tui_form_schema_module_from_value(
+        &resolved.schema,
+        resolved.defaults.as_ref(),
         &form_module,
         &cmd.form_fn,
     )
     .map_err(Report::msg)?;
-    pre_tui::generate_tui_layout_nav_module(
-        &schema_path,
-        format,
-        defaults_path.as_deref(),
+    pre_tui::generate_tui_layout_nav_module_from_value(
+        &resolved.schema,
+        resolved.defaults.as_ref(),
         &layout_module,
         &cmd.layout_fn,
     )

--- a/schemaui-cli/src/web/mod.rs
+++ b/schemaui-cli/src/web/mod.rs
@@ -1,15 +1,16 @@
 use std::fs;
-use std::path::PathBuf;
 
 use color_eyre::eyre::{Report, Result};
+use schemaui::SchemaUI;
 use schemaui::precompile::web::{
-    build_session_snapshot_from_files, write_session_snapshot_json,
-    write_session_snapshot_ts_module,
+    build_session_snapshot, write_session_snapshot_json, write_session_snapshot_ts_module,
 };
 use schemaui::web::session::ServeOptions as WebServeOptions;
-use schemaui::{DocumentFormat, SchemaUI};
 
 use crate::cli::{WebCommand, WebSnapshotCommand};
+use crate::session::diagnostics::DiagnosticCollector;
+use crate::session::format::resolve_format_hint;
+use crate::session::schema_source::{load_optional_document, resolve_session_inputs};
 use crate::session::{SessionBundle, prepare_session};
 
 pub fn run_cli(cmd: WebCommand) -> Result<()> {
@@ -45,48 +46,37 @@ fn execute_web_session(session: SessionBundle, cmd: WebCommand) -> Result<()> {
 }
 
 pub fn run_snapshot_cli(cmd: WebSnapshotCommand) -> Result<()> {
-    // For snapshots we intentionally use a simpler pipeline that only supports
-    // file-based schema/config. This keeps behaviour predictable and mirrors
-    // the `web_snapshot_codegen` example.
-
-    let schema_spec = cmd
-        .common
-        .schema
-        .as_deref()
-        .ok_or_else(|| Report::msg("web-snapshot requires --schema <PATH>"))?;
-    if schema_spec == "-" {
-        return Err(Report::msg(
-            "web-snapshot does not support --schema - (stdin); please pass a file path",
-        ));
-    }
-
+    let schema_spec = cmd.common.schema.as_deref();
     let config_spec = cmd.common.config.as_deref();
-    if config_spec == Some("-") {
-        return Err(Report::msg(
-            "web-snapshot does not support --config - (stdin); please pass a file path",
-        ));
+    let mut diagnostics = DiagnosticCollector::default();
+    let schema_stdin = schema_spec == Some("-");
+    let config_stdin = config_spec == Some("-");
+    if schema_stdin && config_stdin {
+        diagnostics.push_input(
+            "schema/config",
+            "cannot read schema and config from stdin simultaneously; provide inline content, files, or a remote schema",
+        );
     }
-
-    let schema_path = PathBuf::from(schema_spec);
-    if !schema_path.exists() {
-        return Err(Report::msg(format!(
-            "schema path {:?} does not exist",
-            schema_path
-        )));
-    }
-
-    let defaults_path = config_spec.map(PathBuf::from);
-    if let Some(ref p) = defaults_path
-        && !p.exists()
-    {
-        return Err(Report::msg(format!("config path {:?} does not exist", p)));
-    }
-
-    let format = DocumentFormat::from_extension(&schema_path).unwrap_or(DocumentFormat::Json);
-
-    let snapshot =
-        build_session_snapshot_from_files(&schema_path, format, defaults_path.as_deref())
-            .map_err(Report::msg)?;
+    let schema_hint = resolve_format_hint(schema_spec, "schema", &mut diagnostics);
+    let config_hint = resolve_format_hint(config_spec, "config", &mut diagnostics);
+    let schema_document = load_optional_document(
+        schema_spec,
+        schema_hint.hint.format,
+        "schema",
+        schema_hint.blocked || (schema_stdin && config_stdin),
+        &mut diagnostics,
+    );
+    let config_document = load_optional_document(
+        config_spec,
+        config_hint.hint.format,
+        "config",
+        config_hint.blocked || (schema_stdin && config_stdin),
+        &mut diagnostics,
+    );
+    diagnostics.into_result()?;
+    let resolved = resolve_session_inputs(schema_document, config_document).map_err(Report::msg)?;
+    let snapshot = build_session_snapshot(&resolved.schema, resolved.defaults.as_ref())
+        .map_err(Report::msg)?;
 
     fs::create_dir_all(&cmd.out_dir)?;
     let json_out = cmd.out_dir.join("session_snapshot.json");

--- a/schemaui-cli/tests/arg_order.rs
+++ b/schemaui-cli/tests/arg_order.rs
@@ -1,4 +1,3 @@
-use clap::Parser;
 use schemaui_cli::cli::{Cli, Commands};
 
 #[test]
@@ -41,6 +40,24 @@ fn explicit_tui_snapshot_subcommand_accepts_common_args() {
     assert_eq!(cmd.out_dir.to_str(), Some("./out"));
 }
 
+#[test]
+fn alias_flags_are_normalized_before_parsing() {
+    let cli = Cli::parse_from([
+        "schemaui",
+        "--data",
+        "./config.json",
+        "--yes",
+        "--output",
+        "./a.json",
+        "./b.json",
+    ]);
+
+    assert!(cli.command.is_none(), "expected implicit default TUI mode");
+    assert_eq!(cli.common.config.as_deref(), Some("./config.json"));
+    assert!(cli.common.force);
+    assert_eq!(cli.common.outputs, vec!["./a.json", "./b.json"]);
+}
+
 #[cfg(feature = "web")]
 #[test]
 fn explicit_web_subcommand_accepts_common_args() {
@@ -75,6 +92,25 @@ fn trailing_web_token_is_parsed_as_subcommand_after_root_args() {
     assert_eq!(cli.common.schema.as_deref(), Some("./schema.json"));
     assert!(cli.common.force);
     assert_eq!(cmd.common.schema, None);
+}
+
+#[cfg(feature = "web")]
+#[test]
+fn web_host_aliases_are_normalized_before_parsing() {
+    let cli = Cli::parse_from([
+        "schemaui",
+        "web",
+        "--bind",
+        "0.0.0.0",
+        "--listen",
+        "127.0.0.1",
+    ]);
+
+    let Some(Commands::Web(cmd)) = cli.command else {
+        panic!("expected explicit web subcommand");
+    };
+
+    assert_eq!(cmd.host.to_string(), "127.0.0.1");
 }
 
 #[cfg(feature = "web")]

--- a/schemaui-cli/tests/arg_order.rs
+++ b/schemaui-cli/tests/arg_order.rs
@@ -1,4 +1,4 @@
-use schemaui_cli::cli::{Cli, Commands};
+use schemaui_cli::cli::{Cli, Commands, CompletionShell};
 
 #[test]
 fn defaults_to_tui_when_no_subcommand_is_provided() {
@@ -19,6 +19,17 @@ fn explicit_tui_subcommand_accepts_common_args() {
 
     assert_eq!(cmd.common.schema.as_deref(), Some("./schema.json"));
     assert!(cmd.common.force);
+}
+
+#[test]
+fn explicit_completion_subcommand_is_not_rewritten_to_default_tui() {
+    let cli = Cli::parse_from(["schemaui", "completion", "bash"]);
+
+    let Some(Commands::Completion(cmd)) = cli.command else {
+        panic!("expected explicit completion subcommand");
+    };
+
+    assert_eq!(cmd.shell, CompletionShell::Bash);
 }
 
 #[test]

--- a/schemaui-cli/tests/completion.rs
+++ b/schemaui-cli/tests/completion.rs
@@ -1,0 +1,23 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::PredicateBooleanExt;
+use predicates::str::contains;
+
+#[test]
+fn generates_bash_completion_script_with_known_subcommands() {
+    let mut cmd = cargo_bin_cmd!("schemaui");
+    cmd.args(["completion", "bash"]).assert().success().stdout(
+        contains("completion")
+            .and(contains("tui"))
+            .and(contains("tui-snapshot")),
+    );
+}
+
+#[cfg(feature = "web")]
+#[test]
+fn generated_completion_mentions_web_commands_when_enabled() {
+    let mut cmd = cargo_bin_cmd!("schemaui");
+    cmd.args(["completion", "bash"])
+        .assert()
+        .success()
+        .stdout(contains("web").and(contains("web-snapshot")));
+}

--- a/schemaui-cli/tests/output_defaults.rs
+++ b/schemaui-cli/tests/output_defaults.rs
@@ -1,0 +1,109 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use schemaui::OutputDestination;
+use schemaui_cli::cli::CommonArgs;
+use schemaui_cli::session::prepare_session;
+use serde_json::{Value, json};
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "schemaui_output_defaults_{label}_{}_{}",
+        std::process::id(),
+        nanos
+    ));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+fn write_json(path: &Path, value: &Value) {
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(value).expect("serialize json"),
+    )
+    .expect("write json file");
+}
+
+fn base_args(schema: String, config: String) -> CommonArgs {
+    CommonArgs {
+        schema: Some(schema),
+        config: Some(config),
+        title: None,
+        outputs: vec![],
+        temp_file: None,
+        no_temp_file: false,
+        no_pretty: false,
+        force: false,
+    }
+}
+
+#[test]
+fn prepare_session_defaults_to_stdout_when_no_output_is_given() {
+    let temp = unique_temp_dir("stdout");
+    let schema_path = temp.join("schema.json");
+    let config_path = temp.join("config.json");
+    write_json(
+        &schema_path,
+        &json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "enabled": { "type": "boolean" }
+            }
+        }),
+    );
+    write_json(&config_path, &json!({ "enabled": true }));
+
+    let session = prepare_session(&base_args(
+        schema_path.to_string_lossy().into_owned(),
+        config_path.to_string_lossy().into_owned(),
+    ))
+    .expect("prepare session");
+
+    let output = session.output.expect("output settings");
+    assert_eq!(output.destinations.len(), 1);
+    assert!(matches!(output.destinations[0], OutputDestination::Stdout));
+
+    let _ = fs::remove_dir_all(temp);
+}
+
+#[test]
+fn prepare_session_respects_explicit_temp_file_override() {
+    let temp = unique_temp_dir("temp_file");
+    let schema_path = temp.join("schema.json");
+    let config_path = temp.join("config.json");
+    let explicit_output = temp.join("custom-output.json");
+    write_json(
+        &schema_path,
+        &json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "enabled": { "type": "boolean" }
+            }
+        }),
+    );
+    write_json(&config_path, &json!({ "enabled": true }));
+
+    let mut args = base_args(
+        schema_path.to_string_lossy().into_owned(),
+        config_path.to_string_lossy().into_owned(),
+    );
+    args.temp_file = Some(explicit_output.clone());
+
+    let session = prepare_session(&args).expect("prepare session");
+
+    let output = session.output.expect("output settings");
+    assert_eq!(output.destinations.len(), 1);
+    assert!(matches!(
+        &output.destinations[0],
+        OutputDestination::File(path) if path == &explicit_output
+    ));
+
+    let _ = fs::remove_dir_all(temp);
+}

--- a/schemaui-cli/tests/schema_auto_detection.rs
+++ b/schemaui-cli/tests/schema_auto_detection.rs
@@ -1,0 +1,250 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use schemaui_cli::cli::{CommonArgs, TuiSnapshotCommand};
+use schemaui_cli::session::prepare_session;
+use serde_json::{Value, json};
+
+#[cfg(feature = "web")]
+use schemaui_cli::cli::WebSnapshotCommand;
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "schemaui_schema_auto_{label}_{}_{}",
+        std::process::id(),
+        nanos
+    ));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+fn write_json(path: &Path, value: &Value) {
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(value).expect("serialize json"),
+    )
+    .expect("write json file");
+}
+
+fn base_args(schema: Option<String>, config: Option<String>) -> CommonArgs {
+    CommonArgs {
+        schema,
+        config,
+        title: None,
+        outputs: vec![],
+        temp_file: None,
+        no_temp_file: true,
+        no_pretty: false,
+        force: false,
+    }
+}
+
+#[cfg(feature = "remote-schema")]
+fn spawn_schema_server(schema: Value) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind schema server");
+    let addr = listener.local_addr().expect("local addr");
+    let url = format!("http://{addr}/schema.json");
+    let body = serde_json::to_vec(&schema).expect("serialize schema body");
+
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept request");
+        let mut buffer = [0_u8; 2048];
+        let _ = stream.read(&mut buffer);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write response head");
+        stream.write_all(&body).expect("write response body");
+    });
+
+    (url, handle)
+}
+
+#[test]
+fn prepare_session_uses_json_root_schema_and_strips_metadata_from_defaults() {
+    let temp = unique_temp_dir("json_root");
+    let schema = json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Local Schema",
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"]
+    });
+    let schema_path = temp.join("schema.json");
+    let config_path = temp.join("config.json");
+    write_json(&schema_path, &schema);
+    write_json(
+        &config_path,
+        &json!({
+            "$schema": "./schema.json",
+            "name": "alice"
+        }),
+    );
+
+    let session = prepare_session(&base_args(
+        None,
+        Some(config_path.to_string_lossy().into_owned()),
+    ))
+    .expect("prepare session");
+
+    assert_eq!(session.schema, schema);
+    assert_eq!(session.defaults, Some(json!({ "name": "alice" })));
+
+    let _ = fs::remove_dir_all(temp);
+}
+
+#[cfg(feature = "yaml")]
+#[test]
+fn prepare_session_prefers_explicit_local_schema_over_yaml_header_declaration() {
+    let temp = unique_temp_dir("yaml_override");
+    let explicit_schema = json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Explicit Local Schema",
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" }
+        }
+    });
+    let explicit_schema_path = temp.join("explicit.schema.json");
+    let config_path = temp.join("config.yaml");
+    write_json(&explicit_schema_path, &explicit_schema);
+    fs::write(
+        &config_path,
+        "# yaml-language-server: $schema=http://127.0.0.1:9/should-not-be-fetched.json\nname: alice\n",
+    )
+    .expect("write yaml config");
+
+    let session = prepare_session(&base_args(
+        Some(explicit_schema_path.to_string_lossy().into_owned()),
+        Some(config_path.to_string_lossy().into_owned()),
+    ))
+    .expect("prepare session");
+
+    assert_eq!(session.schema, explicit_schema);
+    assert_eq!(session.defaults, Some(json!({ "name": "alice" })));
+
+    let _ = fs::remove_dir_all(temp);
+}
+
+#[cfg(all(feature = "remote-schema", feature = "toml"))]
+#[test]
+fn prepare_session_uses_remote_toml_schema_directive() {
+    let temp = unique_temp_dir("toml_remote");
+    let remote_schema = json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Remote TOML Schema",
+        "type": "object",
+        "properties": {
+            "port": { "type": "integer" }
+        },
+        "required": ["port"]
+    });
+    let (schema_url, handle) = spawn_schema_server(remote_schema.clone());
+    let config_path = temp.join("config.toml");
+    fs::write(
+        &config_path,
+        format!("#:schema {schema_url}\nport = 8080\n"),
+    )
+    .expect("write toml config");
+
+    let session = prepare_session(&base_args(
+        None,
+        Some(config_path.to_string_lossy().into_owned()),
+    ))
+    .expect("prepare session");
+
+    handle.join().expect("schema server thread");
+
+    assert_eq!(session.schema, remote_schema);
+    assert_eq!(session.defaults, Some(json!({ "port": 8080 })));
+
+    let _ = fs::remove_dir_all(temp);
+}
+
+#[cfg(feature = "remote-schema")]
+#[test]
+fn tui_snapshot_accepts_explicit_remote_schema() {
+    let temp = unique_temp_dir("tui_snapshot_remote");
+    let out_dir = temp.join("generated");
+    let schema = json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Remote TUI Snapshot Schema",
+        "type": "object",
+        "properties": {
+            "enabled": { "type": "boolean" }
+        }
+    });
+    let (schema_url, handle) = spawn_schema_server(schema);
+    let config_path = temp.join("config.json");
+    write_json(&config_path, &json!({ "enabled": true }));
+
+    schemaui_cli::tui::run_snapshot_cli(TuiSnapshotCommand {
+        common: base_args(
+            Some(schema_url),
+            Some(config_path.to_string_lossy().into_owned()),
+        ),
+        out_dir: out_dir.clone(),
+        tui_fn: "tui_artifacts".to_string(),
+        form_fn: "tui_form_schema".to_string(),
+        layout_fn: "tui_layout_nav".to_string(),
+    })
+    .expect("run tui snapshot");
+
+    handle.join().expect("schema server thread");
+
+    assert!(out_dir.join("tui_artifacts.rs").exists());
+    assert!(out_dir.join("tui_form_schema.rs").exists());
+    assert!(out_dir.join("tui_layout_nav.rs").exists());
+
+    let _ = fs::remove_dir_all(temp);
+}
+
+#[cfg(all(feature = "web", feature = "yaml"))]
+#[test]
+fn web_snapshot_accepts_yaml_fallback_local_schema_declaration() {
+    let temp = unique_temp_dir("web_snapshot_local");
+    let schema = json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Web Snapshot Local Schema",
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" }
+        }
+    });
+    let schema_path = temp.join("schema.json");
+    let config_path = temp.join("config.yaml");
+    let out_dir = temp.join("snapshots");
+    write_json(&schema_path, &schema);
+    fs::write(&config_path, "# @schema ./schema.json\nname: \"bob\"\n").expect("write yaml config");
+
+    schemaui_cli::web::run_snapshot_cli(WebSnapshotCommand {
+        common: base_args(None, Some(config_path.to_string_lossy().into_owned())),
+        out_dir: out_dir.clone(),
+        ts_export: "SessionSnapshot".to_string(),
+    })
+    .expect("run web snapshot");
+
+    let snapshot_path = out_dir.join("session_snapshot.json");
+    let snapshot: Value =
+        serde_json::from_str(&fs::read_to_string(&snapshot_path).expect("read web snapshot json"))
+            .expect("parse web snapshot json");
+
+    assert_eq!(snapshot["title"], "Web Snapshot Local Schema");
+    assert_eq!(snapshot["data"], json!({ "name": "bob" }));
+    assert!(out_dir.join("session_snapshot.ts").exists());
+
+    let _ = fs::remove_dir_all(temp);
+}

--- a/schemaui-cli/tests/schema_auto_detection.rs
+++ b/schemaui-cli/tests/schema_auto_detection.rs
@@ -71,6 +71,33 @@ fn spawn_schema_server(schema: Value) -> (String, thread::JoinHandle<()>) {
     (url, handle)
 }
 
+fn opaque_object_schema() -> Value {
+    json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Opaque Object Schema",
+        "type": "object",
+        "properties": {
+            "permissions": {
+                "allOf": [
+                    { "$ref": "#/definitions/PermissionsToml" }
+                ],
+                "description": "Named permission profiles."
+            },
+            "features": {
+                "type": "object",
+                "properties": {
+                    "apps": { "type": "boolean" }
+                }
+            }
+        },
+        "definitions": {
+            "PermissionsToml": {
+                "type": "object"
+            }
+        }
+    })
+}
+
 #[test]
 fn prepare_session_uses_json_root_schema_and_strips_metadata_from_defaults() {
     let temp = unique_temp_dir("json_root");
@@ -245,6 +272,47 @@ fn web_snapshot_accepts_yaml_fallback_local_schema_declaration() {
     assert_eq!(snapshot["title"], "Web Snapshot Local Schema");
     assert_eq!(snapshot["data"], json!({ "name": "bob" }));
     assert!(out_dir.join("session_snapshot.ts").exists());
+
+    let _ = fs::remove_dir_all(temp);
+}
+
+#[cfg(all(feature = "web", feature = "remote-schema", feature = "toml"))]
+#[test]
+fn web_snapshot_accepts_remote_schema_with_opaque_object_fields() {
+    let temp = unique_temp_dir("web_snapshot_remote_opaque_object");
+    let out_dir = temp.join("snapshots");
+    let (schema_url, handle) = spawn_schema_server(opaque_object_schema());
+    let config_path = temp.join("config.toml");
+    fs::write(
+        &config_path,
+        format!("#:schema {schema_url}\n[features]\napps = true\n"),
+    )
+    .expect("write toml config");
+
+    schemaui_cli::web::run_snapshot_cli(WebSnapshotCommand {
+        common: base_args(None, Some(config_path.to_string_lossy().into_owned())),
+        out_dir: out_dir.clone(),
+        ts_export: "SessionSnapshot".to_string(),
+    })
+    .expect("run web snapshot");
+
+    handle.join().expect("schema server thread");
+
+    let snapshot_path = out_dir.join("session_snapshot.json");
+    let snapshot: Value =
+        serde_json::from_str(&fs::read_to_string(&snapshot_path).expect("read web snapshot json"))
+            .expect("parse web snapshot json");
+
+    assert_eq!(snapshot["title"], "Opaque Object Schema");
+    assert_eq!(snapshot["data"], json!({ "features": { "apps": true } }));
+    assert!(
+        snapshot["ui_ast"]["roots"]
+            .as_array()
+            .expect("ui ast roots")
+            .iter()
+            .any(|node| node["pointer"] == "/permissions"),
+        "opaque object fields should remain representable in the generated UI AST",
+    );
 
     let _ = fs::remove_dir_all(temp);
 }

--- a/src/io/format.rs
+++ b/src/io/format.rs
@@ -1,9 +1,12 @@
 use std::{fmt, path::Path};
 
+#[cfg(not(any(feature = "json", feature = "yaml", feature = "toml")))]
+compile_error!("schemaui requires at least one document format feature: json, yaml, or toml");
+
 /// Supported data formats for input/output layers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DocumentFormat {
-    #[default]
+    #[cfg(feature = "json")]
     Json,
     #[cfg(feature = "yaml")]
     Yaml,
@@ -11,9 +14,37 @@ pub enum DocumentFormat {
     Toml,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DocumentFormatProbe {
+    Known(DocumentFormat),
+    UnsupportedFeature {
+        format_name: &'static str,
+        feature_flag: &'static str,
+    },
+    Unknown,
+}
+
+impl Default for DocumentFormat {
+    fn default() -> Self {
+        #[cfg(feature = "json")]
+        {
+            Self::Json
+        }
+        #[cfg(all(not(feature = "json"), feature = "yaml"))]
+        {
+            Self::Yaml
+        }
+        #[cfg(all(not(feature = "json"), not(feature = "yaml"), feature = "toml"))]
+        {
+            Self::Toml
+        }
+    }
+}
+
 impl fmt::Display for DocumentFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(feature = "json")]
             DocumentFormat::Json => write!(f, "json"),
             #[cfg(feature = "yaml")]
             DocumentFormat::Yaml => write!(f, "yaml"),
@@ -26,14 +57,17 @@ impl fmt::Display for DocumentFormat {
 impl DocumentFormat {
     /// Parse a format keyword (json/yaml/toml) into a `DocumentFormat`.
     pub fn from_keyword(keyword: &str) -> Result<Self, String> {
-        match keyword.to_ascii_lowercase().as_str() {
-            "json" => Ok(DocumentFormat::Json),
-            #[cfg(feature = "yaml")]
-            "yaml" | "yml" => Ok(DocumentFormat::Yaml),
-            #[cfg(feature = "toml")]
-            "toml" => Ok(DocumentFormat::Toml),
-            other => Err(format!(
-                "unsupported format '{other}', available: {}",
+        match Self::probe_keyword(keyword) {
+            DocumentFormatProbe::Known(format) => Ok(format),
+            DocumentFormatProbe::UnsupportedFeature {
+                format_name,
+                feature_flag,
+            } => Err(format!(
+                "format '{format_name}' requires the '{feature_flag}' feature"
+            )),
+            DocumentFormatProbe::Unknown => Err(format!(
+                "unsupported format '{}', available: {}",
+                keyword,
                 Self::keyword_list().join(", ")
             )),
         }
@@ -41,34 +75,120 @@ impl DocumentFormat {
 
     /// Try to infer a format from a file extension.
     pub fn from_extension(path: &Path) -> Option<Self> {
-        let ext = path.extension()?.to_string_lossy().to_ascii_lowercase();
-        match ext.as_str() {
-            "json" => Some(DocumentFormat::Json),
+        match Self::probe_extension(path) {
+            DocumentFormatProbe::Known(format) => Some(format),
+            DocumentFormatProbe::UnsupportedFeature { .. } | DocumentFormatProbe::Unknown => None,
+        }
+    }
+
+    pub fn probe_keyword(keyword: &str) -> DocumentFormatProbe {
+        match keyword.to_ascii_lowercase().as_str() {
+            #[cfg(feature = "json")]
+            "json" => DocumentFormatProbe::Known(DocumentFormat::Json),
+            #[cfg(not(feature = "json"))]
+            "json" => DocumentFormatProbe::UnsupportedFeature {
+                format_name: "json",
+                feature_flag: "json",
+            },
             #[cfg(feature = "yaml")]
-            "yaml" | "yml" => Some(DocumentFormat::Yaml),
+            "yaml" | "yml" => DocumentFormatProbe::Known(DocumentFormat::Yaml),
+            #[cfg(not(feature = "yaml"))]
+            "yaml" | "yml" => DocumentFormatProbe::UnsupportedFeature {
+                format_name: "yaml",
+                feature_flag: "yaml",
+            },
             #[cfg(feature = "toml")]
-            "toml" => Some(DocumentFormat::Toml),
-            _ => None,
+            "toml" => DocumentFormatProbe::Known(DocumentFormat::Toml),
+            #[cfg(not(feature = "toml"))]
+            "toml" => DocumentFormatProbe::UnsupportedFeature {
+                format_name: "toml",
+                feature_flag: "toml",
+            },
+            _ => DocumentFormatProbe::Unknown,
+        }
+    }
+
+    pub fn probe_extension(path: &Path) -> DocumentFormatProbe {
+        let Some(ext) = path.extension() else {
+            return DocumentFormatProbe::Unknown;
+        };
+        let ext = ext.to_string_lossy().to_ascii_lowercase();
+        match ext.as_str() {
+            #[cfg(feature = "json")]
+            "json" => DocumentFormatProbe::Known(DocumentFormat::Json),
+            #[cfg(not(feature = "json"))]
+            "json" => DocumentFormatProbe::UnsupportedFeature {
+                format_name: "json",
+                feature_flag: "json",
+            },
+            #[cfg(feature = "yaml")]
+            "yaml" | "yml" => DocumentFormatProbe::Known(DocumentFormat::Yaml),
+            #[cfg(not(feature = "yaml"))]
+            "yaml" | "yml" => DocumentFormatProbe::UnsupportedFeature {
+                format_name: "yaml",
+                feature_flag: "yaml",
+            },
+            #[cfg(feature = "toml")]
+            "toml" => DocumentFormatProbe::Known(DocumentFormat::Toml),
+            #[cfg(not(feature = "toml"))]
+            "toml" => DocumentFormatProbe::UnsupportedFeature {
+                format_name: "toml",
+                feature_flag: "toml",
+            },
+            _ => DocumentFormatProbe::Unknown,
         }
     }
 
     pub fn keyword_list() -> Vec<&'static str> {
-        #[allow(unused_mut)]
-        let mut items = vec!["json"];
-        #[cfg(feature = "yaml")]
-        items.push("yaml");
-        #[cfg(feature = "toml")]
-        items.push("toml");
-        items
+        vec![
+            #[cfg(feature = "json")]
+            "json",
+            #[cfg(feature = "yaml")]
+            "yaml",
+            #[cfg(feature = "toml")]
+            "toml",
+        ]
     }
 
     pub fn available_formats() -> Vec<DocumentFormat> {
-        #[allow(unused_mut)]
-        let mut formats = vec![DocumentFormat::Json];
-        #[cfg(feature = "yaml")]
-        formats.push(DocumentFormat::Yaml);
-        #[cfg(feature = "toml")]
-        formats.push(DocumentFormat::Toml);
-        formats
+        vec![
+            #[cfg(feature = "json")]
+            DocumentFormat::Json,
+            #[cfg(feature = "yaml")]
+            DocumentFormat::Yaml,
+            #[cfg(feature = "toml")]
+            DocumentFormat::Toml,
+        ]
+    }
+
+    pub fn format_list() -> &'static str {
+        #[cfg(all(feature = "json", feature = "yaml", feature = "toml"))]
+        {
+            "JSON/YAML/TOML"
+        }
+        #[cfg(all(feature = "json", feature = "yaml", not(feature = "toml")))]
+        {
+            "JSON/YAML"
+        }
+        #[cfg(all(feature = "json", not(feature = "yaml"), feature = "toml"))]
+        {
+            "JSON/TOML"
+        }
+        #[cfg(all(not(feature = "json"), feature = "yaml", feature = "toml"))]
+        {
+            "YAML/TOML"
+        }
+        #[cfg(all(feature = "json", not(feature = "yaml"), not(feature = "toml")))]
+        {
+            "JSON"
+        }
+        #[cfg(all(not(feature = "json"), feature = "yaml", not(feature = "toml")))]
+        {
+            "YAML"
+        }
+        #[cfg(all(not(feature = "json"), not(feature = "yaml"), feature = "toml"))]
+        {
+            "TOML"
+        }
     }
 }

--- a/src/io/input.rs
+++ b/src/io/input.rs
@@ -11,6 +11,7 @@ const JSON_SCHEMA_DRAFT: &str = "http://json-schema.org/draft-07/schema#";
 /// Parse structured data in any supported format into a `serde_json::Value`.
 pub fn parse_document_str(contents: &str, format: DocumentFormat) -> Result<Value> {
     match format {
+        #[cfg(feature = "json")]
         DocumentFormat::Json => {
             serde_json::from_str::<Value>(contents).with_context(|| "failed to parse JSON document")
         }
@@ -371,6 +372,7 @@ mod tests {
         assert_eq!(schema["items"]["type"], json!("string"));
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn parse_json_documents() {
         let raw = "{\"enabled\":true}";

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -3,4 +3,4 @@ pub mod output;
 
 mod format;
 
-pub use format::DocumentFormat;
+pub use format::{DocumentFormat, DocumentFormatProbe};

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -55,7 +55,7 @@ impl OutputOptions {
 
 impl Default for OutputOptions {
     fn default() -> Self {
-        Self::new(DocumentFormat::Json)
+        Self::new(DocumentFormat::default())
     }
 }
 
@@ -78,6 +78,7 @@ pub fn emit(value: &Value, options: &OutputOptions) -> Result<()> {
 
 fn serialize_value(value: &Value, options: &OutputOptions) -> Result<String> {
     match options.format {
+        #[cfg(feature = "json")]
         DocumentFormat::Json => {
             if options.pretty {
                 serde_json::to_string_pretty(value).context("failed to serialize JSON")
@@ -121,6 +122,7 @@ fn write_payload(destination: &OutputDestination, payload: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parse_document_str;
     use serde_json::json;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -128,7 +130,7 @@ mod tests {
     #[test]
     fn writes_to_stdout_noop_when_not_configured() {
         let options = OutputOptions {
-            format: DocumentFormat::Json,
+            format: DocumentFormat::default(),
             pretty: true,
             destinations: Vec::new(),
         };
@@ -147,13 +149,14 @@ mod tests {
         );
         let path = dir.join(filename);
         let options = OutputOptions {
-            format: DocumentFormat::Json,
+            format: DocumentFormat::default(),
             pretty: true,
             destinations: vec![OutputDestination::file(&path)],
         };
         emit(&json!({"ok": true}), &options).unwrap();
         let contents = fs::read_to_string(&path).unwrap();
-        assert!(contents.contains("\"ok\""));
+        let parsed = parse_document_str(&contents, options.format).unwrap();
+        assert_eq!(parsed, json!({"ok": true}));
         let _ = fs::remove_file(path);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub(crate) mod tests;
 
 // pub use app::{SchemaUI, UiOptions};
 pub use io::{
-    DocumentFormat,
+    DocumentFormat, DocumentFormatProbe,
     input::{
         parse_document_str, schema_from_data_str, schema_from_data_value, schema_with_defaults,
     },

--- a/src/precompile/mod.rs
+++ b/src/precompile/mod.rs
@@ -1,12 +1,12 @@
 use std::{fs, path::Path};
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
-use crate::io::DocumentFormat;
 use crate::io::input::{parse_document_str, schema_with_defaults};
+use crate::io::{DocumentFormat, DocumentFormatProbe};
 use crate::tui::model::{FormSchema, form_schema_from_ui_ast};
 use crate::tui::state::LayoutNavModel;
 use crate::ui_ast::{UiAst, UiAstBundle, build_ui_ast_bundle};
@@ -79,7 +79,8 @@ pub fn build_ui_artifact_bundle_from_file(
 ) -> Result<UiArtifactBundle> {
     let schema = read_document_file(schema_path, schema_format)?;
     let defaults = if let Some(path) = defaults_path {
-        Some(read_document_file(path, schema_format)?)
+        let format = resolve_file_format(path, schema_format, "defaults file")?;
+        Some(read_document_file(path, format)?)
     } else {
         None
     };
@@ -168,6 +169,24 @@ fn read_document_file(path: &Path, format: DocumentFormat) -> Result<Value> {
     let contents = fs::read_to_string(path)?;
     let schema: Value = parse_document_str(&contents, format)?;
     Ok(schema)
+}
+
+pub(crate) fn resolve_file_format(
+    path: &Path,
+    fallback: DocumentFormat,
+    label: &str,
+) -> Result<DocumentFormat> {
+    match DocumentFormat::probe_extension(path) {
+        DocumentFormatProbe::Known(format) => Ok(format),
+        DocumentFormatProbe::UnsupportedFeature {
+            format_name,
+            feature_flag,
+        } => Err(anyhow!(
+            "{label} {} requires {format_name} support, but this build lacks the '{feature_flag}' feature",
+            path.display()
+        )),
+        DocumentFormatProbe::Unknown => Ok(fallback),
+    }
 }
 
 fn stable_value_bytes(value: &Value) -> Result<Vec<u8>> {

--- a/src/precompile/tui.rs
+++ b/src/precompile/tui.rs
@@ -1,12 +1,24 @@
 use std::{fs, path::Path};
 
 use anyhow::Result;
+use serde_json::Value;
 
 use crate::io::DocumentFormat;
-use crate::precompile::{TuiArtifacts, build_ui_artifact_bundle_from_file};
+use crate::precompile::{
+    TuiArtifacts, build_ui_artifact_bundle, build_ui_artifact_bundle_from_file, resolve_file_format,
+};
 use crate::tui::model::FormSchema;
 use crate::tui::state::LayoutNavModel;
 use crate::ui_ast::UiAst;
+
+/// Build UiAst and TUI artifacts from schema/default values.
+pub fn build_tui_artifacts(
+    schema: &Value,
+    defaults: Option<&Value>,
+) -> Result<(UiAst, TuiArtifacts)> {
+    let bundle = build_ui_artifact_bundle(schema, defaults)?;
+    Ok((bundle.ui.ui_ast, bundle.tui))
+}
 
 /// Build UiAst and TUI artifacts from a schema file.
 ///
@@ -21,6 +33,15 @@ pub fn build_tui_artifacts_from_file(
     Ok((bundle.ui.ui_ast, bundle.tui))
 }
 
+/// Build UiAst and TUI FormSchema from schema/default values.
+pub fn build_tui_form_schema(
+    schema: &Value,
+    defaults: Option<&Value>,
+) -> Result<(UiAst, FormSchema)> {
+    let (ui_ast, tui) = build_tui_artifacts(schema, defaults)?;
+    Ok((ui_ast, tui.form_schema))
+}
+
 /// Build UiAst and TUI FormSchema from a schema file plus optional defaults.
 pub fn build_tui_form_schema_from_file(
     path: &Path,
@@ -29,6 +50,15 @@ pub fn build_tui_form_schema_from_file(
 ) -> Result<(UiAst, FormSchema)> {
     let (ui_ast, tui) = build_tui_artifacts_from_file(path, format, defaults_path)?;
     Ok((ui_ast, tui.form_schema))
+}
+
+/// Build UiAst and a TUI LayoutNavModel from schema/default values.
+pub fn build_tui_layout_nav(
+    schema: &Value,
+    defaults: Option<&Value>,
+) -> Result<(UiAst, LayoutNavModel)> {
+    let (ui_ast, tui) = build_tui_artifacts(schema, defaults)?;
+    Ok((ui_ast, tui.layout_nav))
 }
 
 /// Build UiAst and a TUI LayoutNavModel from a schema file plus optional
@@ -43,6 +73,23 @@ pub fn build_tui_layout_nav_from_file(
 }
 
 /// Generate a Rust module under OUT_DIR that exposes a constructor for
+/// `TuiArtifacts` built from the given schema and optional defaults values.
+pub fn generate_tui_artifacts_module_from_value(
+    schema: &Value,
+    defaults: Option<&Value>,
+    out_module_path: &Path,
+    fn_name: &str,
+) -> Result<()> {
+    let (_ast, artifacts) = build_tui_artifacts(schema, defaults)?;
+    let json = serde_json::to_string_pretty(&artifacts)?;
+    let src = format!(
+        "pub fn {fn_name}() -> schemaui::TuiArtifacts {{\n    serde_json::from_str::<schemaui::TuiArtifacts>(r#\"{json}\"#).expect(\"invalid TUI artifacts JSON\")\n}}\n",
+    );
+    fs::write(out_module_path, src)?;
+    Ok(())
+}
+
+/// Generate a Rust module under OUT_DIR that exposes a constructor for
 /// `TuiArtifacts` built from the given schema and optional defaults.
 pub fn generate_tui_artifacts_module(
     schema_path: &Path,
@@ -51,10 +98,22 @@ pub fn generate_tui_artifacts_module(
     out_module_path: &Path,
     fn_name: &str,
 ) -> Result<()> {
-    let (_ast, artifacts) = build_tui_artifacts_from_file(schema_path, format, defaults_path)?;
-    let json = serde_json::to_string_pretty(&artifacts)?;
+    let (schema, defaults) = load_schema_and_defaults(schema_path, format, defaults_path)?;
+    generate_tui_artifacts_module_from_value(&schema, defaults.as_ref(), out_module_path, fn_name)
+}
+
+/// Generate a Rust module under OUT_DIR that exposes a constructor for
+/// `FormSchema` built from the given schema and optional defaults values.
+pub fn generate_tui_form_schema_module_from_value(
+    schema: &Value,
+    defaults: Option<&Value>,
+    out_module_path: &Path,
+    fn_name: &str,
+) -> Result<()> {
+    let (_ast, form_schema) = build_tui_form_schema(schema, defaults)?;
+    let json = serde_json::to_string_pretty(&form_schema)?;
     let src = format!(
-        "pub fn {fn_name}() -> schemaui::TuiArtifacts {{\n    serde_json::from_str::<schemaui::TuiArtifacts>(r#\"{json}\"#).expect(\"invalid TUI artifacts JSON\")\n}}\n",
+        "pub fn {fn_name}() -> schemaui::FormSchema {{\n    serde_json::from_str::<schemaui::FormSchema>(r#\"{json}\"#).expect(\"invalid generated FormSchema JSON\")\n}}\n",
     );
     fs::write(out_module_path, src)?;
     Ok(())
@@ -78,10 +137,22 @@ pub fn generate_tui_form_schema_module(
     out_module_path: &Path,
     fn_name: &str,
 ) -> Result<()> {
-    let (_ast, form_schema) = build_tui_form_schema_from_file(schema_path, format, defaults_path)?;
-    let json = serde_json::to_string_pretty(&form_schema)?;
+    let (schema, defaults) = load_schema_and_defaults(schema_path, format, defaults_path)?;
+    generate_tui_form_schema_module_from_value(&schema, defaults.as_ref(), out_module_path, fn_name)
+}
+
+/// Generate a Rust module under OUT_DIR that exposes a constructor for
+/// `LayoutNavModel` built from the given schema and optional defaults values.
+pub fn generate_tui_layout_nav_module_from_value(
+    schema: &Value,
+    defaults: Option<&Value>,
+    out_module_path: &Path,
+    fn_name: &str,
+) -> Result<()> {
+    let (_ast, layout_nav) = build_tui_layout_nav(schema, defaults)?;
+    let json = serde_json::to_string_pretty(&layout_nav)?;
     let src = format!(
-        "pub fn {fn_name}() -> schemaui::FormSchema {{\n    serde_json::from_str::<schemaui::FormSchema>(r#\"{json}\"#).expect(\"invalid generated FormSchema JSON\")\n}}\n",
+        "pub fn {fn_name}() -> schemaui::LayoutNavModel {{\n    serde_json::from_str::<schemaui::LayoutNavModel>(r#\"{json}\"#).expect(\"invalid generated LayoutNavModel JSON\")\n}}\n",
     );
     fs::write(out_module_path, src)?;
     Ok(())
@@ -105,11 +176,23 @@ pub fn generate_tui_layout_nav_module(
     out_module_path: &Path,
     fn_name: &str,
 ) -> Result<()> {
-    let (_ast, layout_nav) = build_tui_layout_nav_from_file(schema_path, format, defaults_path)?;
-    let json = serde_json::to_string_pretty(&layout_nav)?;
-    let src = format!(
-        "pub fn {fn_name}() -> schemaui::LayoutNavModel {{\n    serde_json::from_str::<schemaui::LayoutNavModel>(r#\"{json}\"#).expect(\"invalid generated LayoutNavModel JSON\")\n}}\n",
-    );
-    fs::write(out_module_path, src)?;
-    Ok(())
+    let (schema, defaults) = load_schema_and_defaults(schema_path, format, defaults_path)?;
+    generate_tui_layout_nav_module_from_value(&schema, defaults.as_ref(), out_module_path, fn_name)
+}
+
+fn load_schema_and_defaults(
+    schema_path: &Path,
+    format: DocumentFormat,
+    defaults_path: Option<&Path>,
+) -> Result<(Value, Option<Value>)> {
+    let schema = std::fs::read_to_string(schema_path)?;
+    let schema = crate::parse_document_str(&schema, format)?;
+    let defaults = if let Some(path) = defaults_path {
+        let format = resolve_file_format(path, format, "defaults file")?;
+        let raw = std::fs::read_to_string(path)?;
+        Some(crate::parse_document_str(&raw, format)?)
+    } else {
+        None
+    };
+    Ok((schema, defaults))
 }

--- a/src/precompile/web.rs
+++ b/src/precompile/web.rs
@@ -4,31 +4,22 @@ use anyhow::Result;
 use serde_json::Value;
 
 use crate::io::{DocumentFormat, input::parse_document_str};
-use crate::precompile::build_ui_artifact_bundle;
+use crate::precompile::{build_ui_artifact_bundle, resolve_file_format};
 use crate::schema::metadata::root_schema_header;
 use crate::web::session::SessionResponse;
 
-/// Build a minimal Web session snapshot (SessionResponse) from a schema file
-/// and optional defaults file. This mirrors the runtime WebSessionBuilder
-/// logic but is intended for use at compile-time or in external codegen
-/// tools.
-pub fn build_session_snapshot_from_files(
-    schema_path: &Path,
-    schema_format: DocumentFormat,
-    defaults_path: Option<&Path>,
+/// Build a minimal Web session snapshot (SessionResponse) from a schema value
+/// and optional defaults value.
+pub fn build_session_snapshot(
+    schema_value: &Value,
+    defaults_value: Option<&Value>,
 ) -> Result<SessionResponse> {
-    let schema_raw = fs::read_to_string(schema_path)?;
-    let schema_value: Value = parse_document_str(&schema_raw, schema_format)?;
+    let defaults_value = defaults_value
+        .cloned()
+        .unwrap_or_else(|| Value::Object(Default::default()));
 
-    let defaults_value: Value = if let Some(path) = defaults_path {
-        let raw = fs::read_to_string(path)?;
-        parse_document_str(&raw, schema_format)?
-    } else {
-        Value::Object(Default::default())
-    };
-
-    let (title, description) = root_schema_header(&schema_value);
-    let bundle = build_ui_artifact_bundle(&schema_value, Some(&defaults_value))?;
+    let (title, description) = root_schema_header(schema_value);
+    let bundle = build_ui_artifact_bundle(schema_value, Some(&defaults_value))?;
     let (ui_ast, layout) = bundle.ui.into_parts();
 
     let formats: Vec<String> = DocumentFormat::available_formats()
@@ -44,6 +35,29 @@ pub fn build_session_snapshot_from_files(
         formats,
         layout: Some(layout),
     })
+}
+
+/// Build a minimal Web session snapshot (SessionResponse) from a schema file
+/// and optional defaults file. This mirrors the runtime WebSessionBuilder
+/// logic but is intended for use at compile-time or in external codegen
+/// tools.
+pub fn build_session_snapshot_from_files(
+    schema_path: &Path,
+    schema_format: DocumentFormat,
+    defaults_path: Option<&Path>,
+) -> Result<SessionResponse> {
+    let schema_raw = fs::read_to_string(schema_path)?;
+    let schema_value: Value = parse_document_str(&schema_raw, schema_format)?;
+
+    let defaults_value = if let Some(path) = defaults_path {
+        let format = resolve_file_format(path, schema_format, "defaults file")?;
+        let raw = fs::read_to_string(path)?;
+        Some(parse_document_str(&raw, format)?)
+    } else {
+        None
+    };
+
+    build_session_snapshot(&schema_value, defaults_value.as_ref())
 }
 
 /// Write a SessionResponse snapshot as pretty JSON to a file.

--- a/src/tests/io/format_tests.rs
+++ b/src/tests/io/format_tests.rs
@@ -1,0 +1,93 @@
+use std::path::Path;
+
+use crate::{DocumentFormat, DocumentFormatProbe};
+
+#[test]
+fn default_format_matches_first_available_format() {
+    let available = DocumentFormat::available_formats();
+    assert!(!available.is_empty());
+    assert_eq!(DocumentFormat::default(), available[0]);
+}
+
+#[test]
+fn enabled_keywords_round_trip() {
+    for format in DocumentFormat::available_formats() {
+        let keyword = format.to_string();
+        assert_eq!(DocumentFormat::from_keyword(&keyword), Ok(format));
+    }
+}
+
+#[test]
+fn enabled_extensions_round_trip() {
+    #[cfg(feature = "json")]
+    assert_eq!(
+        DocumentFormat::probe_extension(Path::new("config.json")),
+        DocumentFormatProbe::Known(DocumentFormat::Json)
+    );
+
+    #[cfg(feature = "yaml")]
+    {
+        assert_eq!(
+            DocumentFormat::probe_extension(Path::new("config.yaml")),
+            DocumentFormatProbe::Known(DocumentFormat::Yaml)
+        );
+        assert_eq!(
+            DocumentFormat::probe_extension(Path::new("config.yml")),
+            DocumentFormatProbe::Known(DocumentFormat::Yaml)
+        );
+    }
+
+    #[cfg(feature = "toml")]
+    assert_eq!(
+        DocumentFormat::probe_extension(Path::new("config.toml")),
+        DocumentFormatProbe::Known(DocumentFormat::Toml)
+    );
+}
+
+#[cfg(not(feature = "json"))]
+#[test]
+fn json_keyword_reports_missing_feature() {
+    assert_eq!(
+        DocumentFormat::from_keyword("json"),
+        Err("format 'json' requires the 'json' feature".to_string())
+    );
+    assert_eq!(
+        DocumentFormat::probe_extension(Path::new("config.json")),
+        DocumentFormatProbe::UnsupportedFeature {
+            format_name: "json",
+            feature_flag: "json",
+        }
+    );
+}
+
+#[cfg(not(feature = "yaml"))]
+#[test]
+fn yaml_keyword_reports_missing_feature() {
+    assert_eq!(
+        DocumentFormat::from_keyword("yaml"),
+        Err("format 'yaml' requires the 'yaml' feature".to_string())
+    );
+    assert_eq!(
+        DocumentFormat::probe_extension(Path::new("config.yaml")),
+        DocumentFormatProbe::UnsupportedFeature {
+            format_name: "yaml",
+            feature_flag: "yaml",
+        }
+    );
+}
+
+#[cfg(not(feature = "toml"))]
+#[test]
+fn toml_keyword_reports_missing_feature() {
+    assert_eq!(
+        DocumentFormat::from_keyword("toml"),
+        Err("format 'toml' requires the 'toml' feature".to_string())
+    );
+    assert_eq!(
+        DocumentFormat::probe_extension(Path::new("config.toml")),
+        DocumentFormatProbe::UnsupportedFeature {
+            format_name: "toml",
+            feature_flag: "toml",
+        }
+    );
+}

--- a/src/tests/io/mod.rs
+++ b/src/tests/io/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod format_tests;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,9 @@
+pub(crate) mod io;
+#[cfg(feature = "json")]
 pub(crate) mod schema;
+#[cfg(feature = "json")]
 pub(crate) mod tui;
+#[cfg(feature = "json")]
 pub(crate) mod ui_ast;
+#[cfg(all(feature = "json", feature = "web"))]
 pub(crate) mod web;

--- a/src/tests/ui_ast/layout_tests.rs
+++ b/src/tests/ui_ast/layout_tests.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use serde_json::{Value, json};
 
 use crate::io::{DocumentFormat, input::parse_document_str};
-use crate::ui_ast::{build_ui_ast, index, layout};
+use crate::ui_ast::{UiNodeKind, build_ui_ast, index, layout};
 
 fn schema_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -165,5 +165,74 @@ fn layout_preserves_declared_root_and_nested_property_order() {
         child_pointers,
         vec!["/zeta/network", "/zeta/auth"],
         "nested section order should follow schema declaration order",
+    );
+}
+
+#[test]
+fn build_ui_ast_accepts_object_only_allof_refs_without_crashing() {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "permissions": {
+                "allOf": [
+                    { "$ref": "#/definitions/PermissionsToml" }
+                ]
+            },
+            "features": {
+                "type": "object",
+                "properties": {
+                    "apps": { "type": "boolean" }
+                }
+            }
+        },
+        "definitions": {
+            "PermissionsToml": {
+                "type": "object"
+            }
+        }
+    });
+
+    let ast = build_ui_ast(&schema).expect("runtime UiAst");
+    assert_eq!(
+        ast.roots.len(),
+        2,
+        "all top-level roots should still be built"
+    );
+
+    let permissions = ast
+        .roots
+        .iter()
+        .find(|node| node.pointer == "/permissions")
+        .expect("permissions root");
+    assert_eq!(permissions.default_value, Some(json!({})));
+    assert!(
+        matches!(
+            permissions.kind,
+            UiNodeKind::Object {
+                ref children,
+                ref required
+            } if children.is_empty() && required.is_empty()
+        ),
+        "opaque object schemas should degrade to an empty object boundary instead of crashing",
+    );
+
+    let features = ast
+        .roots
+        .iter()
+        .find(|node| node.pointer == "/features")
+        .expect("features root");
+    assert!(
+        matches!(
+            features.kind,
+            UiNodeKind::Object { ref children, .. }
+                if children.iter().any(|child| child.pointer == "/features/apps")
+        ),
+        "ordinary object schemas should remain fully traversable",
+    );
+
+    let ui_layout = layout::build_ui_layout(&ast);
+    assert!(
+        ui_layout.roots.iter().any(|root| root.id == "features"),
+        "layout should still be buildable when an opaque object field is present",
     );
 }

--- a/src/tests/web/web_snapshot_tests.rs
+++ b/src/tests/web/web_snapshot_tests.rs
@@ -26,6 +26,33 @@ fn defaults_value() -> Value {
     })
 }
 
+fn opaque_object_schema() -> Value {
+    json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Opaque Object Schema",
+        "type": "object",
+        "properties": {
+            "permissions": {
+                "allOf": [
+                    { "$ref": "#/definitions/PermissionsToml" }
+                ],
+                "description": "Named permission profiles."
+            },
+            "features": {
+                "type": "object",
+                "properties": {
+                    "apps": { "type": "boolean" }
+                }
+            }
+        },
+        "definitions": {
+            "PermissionsToml": {
+                "type": "object"
+            }
+        }
+    })
+}
+
 fn issue72_schema() -> Value {
     json!({
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -48,6 +75,30 @@ fn issue72_schema() -> Value {
         "required": [],
         "additionalProperties": false
     })
+}
+
+#[test]
+fn web_session_builder_accepts_opaque_object_fields() {
+    let snapshot = WebSessionBuilder::new(opaque_object_schema())
+        .with_initial_data(json!({
+            "features": {
+                "apps": true
+            }
+        }))
+        .build()
+        .expect("web session config")
+        .session_response();
+
+    assert_eq!(snapshot.title.as_deref(), Some("Opaque Object Schema"));
+    assert_eq!(snapshot.data, json!({ "features": { "apps": true } }));
+    assert!(
+        snapshot
+            .ui_ast
+            .roots
+            .iter()
+            .any(|node| node.pointer == "/permissions"),
+        "opaque object fields should remain representable in the web session UI AST",
+    );
 }
 
 #[test]

--- a/src/ui_ast/builder.rs
+++ b/src/ui_ast/builder.rs
@@ -25,10 +25,11 @@ pub fn build_ui_ast(raw: &Value) -> Result<UiAst> {
         bail!("root schema must describe an object");
     }
 
+    let fallback_object = ObjectValidation::default();
     let object = root_object
         .object
         .as_ref()
-        .context("root schema must define properties")?;
+        .map_or(&fallback_object, Box::as_ref);
     let required = required_list(object);
 
     let mut active_refs = Vec::new();
@@ -151,10 +152,8 @@ fn visit_schema(
     }
 
     if is_object_schema(schema) {
-        let obj = schema
-            .object
-            .as_ref()
-            .context("object schema missing properties")?;
+        let fallback_object = ObjectValidation::default();
+        let obj = schema.object.as_ref().map_or(&fallback_object, Box::as_ref);
         let mut children = Vec::new();
         let required_fields = required_list(obj);
         for (name, child_schema) in &obj.properties {
@@ -291,10 +290,8 @@ fn visit_kind(
     }
 
     if is_object_schema(schema) {
-        let obj = schema
-            .object
-            .as_ref()
-            .context("object schema missing properties")?;
+        let fallback_object = ObjectValidation::default();
+        let obj = schema.object.as_ref().map_or(&fallback_object, Box::as_ref);
         let required_fields = required_list(obj);
         let mut children = Vec::new();
         for (name, schema) in &obj.properties {

--- a/src/web/session.rs
+++ b/src/web/session.rs
@@ -513,7 +513,11 @@ fn encode_value(
     format: DocumentFormat,
     pretty: bool,
 ) -> Result<String, anyhow::Error> {
+    #[cfg(all(not(feature = "json"), not(feature = "toml")))]
+    let _ = pretty;
+
     match format {
+        #[cfg(feature = "json")]
         DocumentFormat::Json => {
             if pretty {
                 Ok(serde_json::to_string_pretty(value)?)


### PR DESCRIPTION
enhance: support the schema.json auto-detection and support remote schema.json

# Config Schema Auto-Detection

When using:

```bash
-c config.json | config.yaml | config.toml
```

the tool **automatically detects schema declarations** from the file header (or root for JSON) and enables validation.

Supports:

* 🌐 Remote (`https://...`)
* 📁 Local (`./schema.json`)

---

## Priority

```text
CLI (-s / --schema)
  > file declaration
  > default
```

---

## Supported Formats

### JSON (Official Standard)

```json
{
  "$schema": "https://example.com/schema.json"
}
```

* `$schema` must be at root
* Defined by [JSON Schema](https://json-schema.org/understanding-json-schema/reference/schema?utm_source=chatgpt.com) spec ([JSON Schema][1])

---

### TOML (De-facto Standard)

```toml
#:schema https://example.com/schema.json

[abc]
xxx = "xxx"
```

* Top comment directive
* Used by Taplo / Tombi ecosystem ([[Tombi Toml](https://tombi-toml.github.io/tombi/docs/json-schema/?utm_source=chatgpt.com)][2])

---

### YAML (Ecosystem Convention)

```yaml
# yaml-language-server: $schema=https://example.com/schema.json
```

Fallback:

```yaml
# @schema https://example.com/schema.json
```

* YAML spec itself **does not define schema binding**
* Relies on tooling conventions

---

## Summary

```text
JSON:
  $schema              (official)

TOML:
  #:schema             (de-facto)

YAML:
  # yaml-language-server: $schema=...
  # @schema ...        (fallback)

Priority:
  CLI > header > default

Schema source:
  remote + local
```

---

## References

* JSON Schema `$schema`
  [https://json-schema.org/understanding-json-schema/reference/schema](https://json-schema.org/understanding-json-schema/reference/schema)
* TOML schema directive (Taplo/Tombi)
  [https://taplo.tamasfe.dev/configuration/directives.html](https://taplo.tamasfe.dev/configuration/directives.html)
* YAML schema (language server convention)
  [https://github.com/redhat-developer/yaml-language-server](https://github.com/redhat-developer/yaml-language-server)

---

[1]: https://json-schema.org/understanding-json-schema/reference/schema?utm_source=chatgpt.com "JSON Schema - Dialect and vocabulary declaration"
[2]: https://tombi-toml.github.io/tombi/docs/json-schema/?utm_source=chatgpt.com "JSON Schema"