### PR TITLE
fix: overlay input truncation fix

### DIFF
--- a/src/tui/view/components/fields.rs
+++ b/src/tui/view/components/fields.rs
@@ -53,7 +53,9 @@ pub fn render_fields(
         return;
     }
 
-    let content_width = field_area.width.saturating_sub(4);
+    let content_width = field_area
+        .width
+        .saturating_sub(4 + highlight_symbol_width());
     let mut items = Vec::with_capacity(section.fields.len());
     let mut cursor_hint: Option<CursorHint> = None;
     let mut field_heights = Vec::with_capacity(section.fields.len());

--- a/src/tui/view/components/fields.rs
+++ b/src/tui/view/components/fields.rs
@@ -55,7 +55,7 @@ pub fn render_fields(
 
     let content_width = field_area
         .width
-        .saturating_sub(4 + highlight_symbol_width());
+        .saturating_sub(8 + highlight_symbol_width());
     let mut items = Vec::with_capacity(section.fields.len());
     let mut cursor_hint: Option<CursorHint> = None;
     let mut field_heights = Vec::with_capacity(section.fields.len());


### PR DESCRIPTION

This PR fixes issue #102. 

The initial bug was overlay input truncates right characters when editing String arrays with Ctrl+E. This has been fixed by reserving width for the list block border and the selected-item highlight symbol.

@YuniqueUnic please let me know if this looks good and can be merged. thanks!