### PR TITLE
fix(cli): restore clap-native version flags with derive-based commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,46 +59,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "argh"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211818e820cda9ca6f167a64a5c808837366a6dfd807157c64c1304c486cd033"
-dependencies = [
- "argh_derive",
- "argh_shared",
-]
-
-[[package]]
-name = "argh_complete"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8dffc879097ecf0b672f84aaed1268ae6c740e8a7ffc0dd9ef8fd2a731b69"
-dependencies = [
- "argh_shared",
-]
-
-[[package]]
-name = "argh_derive"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c442a9d18cef5dde467405d27d461d080d68972d6d0dfd0408265b6749ec427d"
-dependencies = [
- "argh_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "argh_shared"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ade012bac4db278517a0132c8c10c6427025868dca16c801087c28d5a411f1"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "assert_cmd"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +340,53 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -2543,9 +2550,9 @@ dependencies = [
 name = "schemaui-cli"
 version = "0.5.3"
 dependencies = [
- "argh",
- "argh_complete",
  "assert_cmd",
+ "clap",
+ "clap_complete",
  "color-eyre",
  "predicates",
  "reqwest",

--- a/docs/en/cli_usage.md
+++ b/docs/en/cli_usage.md
@@ -84,24 +84,22 @@ schemaui tui --schema ./schema.json
 
 ### Shell completion
 
-`schemaui-cli` now ships an `argh`-backed completion generator:
+`schemaui-cli` now ships a `clap_complete`-backed completion generator:
 
 ```bash
 schemaui completion bash > ~/.local/share/bash-completion/completions/schemaui
 schemaui completion zsh > ~/.zfunc/_schemaui
 schemaui completion fish > ~/.config/fish/completions/schemaui.fish
-schemaui completion nushell > ~/.config/nushell/completions/schemaui.nu
+schemaui completion powershell > ~/.config/powershell/completions/_schemaui.ps1
 ```
 
-Supported shells are `bash`, `zsh`, `fish`, and `nushell`. PowerShell is not
-listed yet because upstream `argh_complete` does not currently ship a PowerShell
-generator.
+Supported shells are `bash`, `zsh`, `fish`, and `powershell`.
 
 ## 2. Execution Flow
 
 ```
 ┌────────┐ args┌───────────────┐ schema/config ┌──────────────┐ result ┌────────────┐
-│  argh  ├────▶│ InputSource   ├──────────────▶│ SchemaUI     ├──────▶│ io::output │
+│  clap  ├────▶│ InputSource   ├──────────────▶│ SchemaUI     ├──────▶│ io::output │
 └────┬───┘     └─────────┬─────┘               │ (library)    │        └────┬───────┘
      │ diagnostics       │ format hint         └─────┬────────┘             │  writes
 ┌────▼─────────┐         │ DocumentFormat            │ validator            ▼  files/stdout

--- a/docs/zh/cli_usage.zh.md
+++ b/docs/zh/cli_usage.zh.md
@@ -29,23 +29,22 @@ schemaui tui --schema ./schema.json
 
 ### Shell completion
 
-`schemaui-cli` 现在内置了基于 `argh_complete` 的补全脚本生成能力：
+`schemaui-cli` 现在内置了基于 `clap_complete` 的补全脚本生成能力：
 
 ```bash
 schemaui completion bash > ~/.local/share/bash-completion/completions/schemaui
 schemaui completion zsh > ~/.zfunc/_schemaui
 schemaui completion fish > ~/.config/fish/completions/schemaui.fish
-schemaui completion nushell > ~/.config/nushell/completions/schemaui.nu
+schemaui completion powershell > ~/.config/powershell/completions/_schemaui.ps1
 ```
 
-当前官方支持的 shell 是 `bash`、`zsh`、`fish`、`nushell`。PowerShell
-还没有接入，因为上游 `argh_complete` 目前没有提供 PowerShell generator。
+当前支持的 shell 是 `bash`、`zsh`、`fish`、`powershell`。
 
 ## 2. 执行流程
 
 ```
 ┌────────┐ args┌───────────────┐ schema/config ┌──────────────┐ result ┌────────────┐
-│  argh  ├────▶│ InputSource   ├──────────────▶│ SchemaUI     ├──────▶│ io::output │
+│  clap  ├────▶│ InputSource   ├──────────────▶│ SchemaUI     ├──────▶│ io::output │
 └────┬───┘     └─────────┬─────┘               │ (library)    │        └────┬───────┘
      │ diagnostics       │ format hint         └─────┬────────┘             │  writes
 ┌────▼─────────┐         │ DocumentFormat            │ validator            ▼  files/stdout

--- a/schemaui-cli/Cargo.toml
+++ b/schemaui-cli/Cargo.toml
@@ -28,8 +28,8 @@ path = "src/main.rs"
 schemaui = { path = "..", version = "0.10.1", default-features = false, features = ["tui"] }
 serde_json = "1"
 color-eyre = "0.6"
-argh = "0.1"
-argh_complete = "0.1"
+clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context"] }
+clap_complete = "4"
 tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
 reqwest = { version = "0.13", features = ["blocking"], optional = true }
 url = "2"

--- a/schemaui-cli/src/cli.rs
+++ b/schemaui-cli/src/cli.rs
@@ -1,37 +1,53 @@
 use std::path::PathBuf;
 
-use clap::{
-    Arg, ArgAction, ArgMatches, Command, CommandFactory, ValueEnum, builder::EnumValueParser,
-    value_parser,
-};
-
 #[cfg(feature = "web")]
 use std::net::IpAddr;
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+use clap::{ArgAction, Args, CommandFactory, Parser, Subcommand, ValueEnum, value_parser};
+
+#[derive(Parser, Debug, Clone, Default, PartialEq, Eq)]
+#[command(
+    name = "schemaui",
+    about = "Render JSON Schemas as interactive TUIs or Web UIs",
+    version,
+    propagate_version = true,
+    disable_help_subcommand = true,
+    subcommand_precedence_over_arg = true
+)]
 pub struct Cli {
+    #[command(flatten)]
     pub common: CommonArgs,
+    #[command(subcommand)]
     pub command: Option<Commands>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub enum Commands {
+    #[command(about = "Generate shell completion scripts for the schemaui CLI")]
     Completion(CompletionCommand),
+    #[command(about = "Launch the interactive terminal UI")]
     Tui(TuiCommand),
     #[cfg(feature = "web")]
+    #[command(about = "Launch the interactive web UI instead of the terminal UI")]
     Web(WebCommand),
     #[cfg(feature = "web")]
+    #[command(about = "Precompute Web session snapshots instead of launching the UI")]
     WebSnapshot(WebSnapshotCommand),
+    #[command(
+        about = "Precompute TUI FormSchema/LayoutNavModel modules instead of launching the UI"
+    )]
     TuiSnapshot(TuiSnapshotCommand),
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Args, Debug, Clone, Default, PartialEq, Eq)]
 pub struct TuiCommand {
+    #[command(flatten)]
     pub common: CommonArgs,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Args, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CompletionCommand {
+    #[arg(help = "target shell: bash, zsh, fish, or powershell")]
     pub shell: CompletionShell,
 }
 
@@ -48,40 +64,154 @@ pub enum CompletionShell {
 }
 
 #[cfg(feature = "web")]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
 pub struct WebCommand {
+    #[command(flatten)]
     pub common: CommonArgs,
+    #[arg(
+        short = 'l',
+        long = "host",
+        visible_aliases = ["bind", "listen"],
+        value_name = "IP",
+        help = "bind address for the temporary HTTP server",
+        value_parser = value_parser!(IpAddr),
+        default_value = "127.0.0.1"
+    )]
     pub host: IpAddr,
+    #[arg(
+        short = 'p',
+        long = "port",
+        value_name = "PORT",
+        help = "bind port for the temporary HTTP server (0 picks a random free port)",
+        value_parser = value_parser!(u16),
+        default_value_t = 0
+    )]
     pub port: u16,
 }
 
 #[cfg(feature = "web")]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
 pub struct WebSnapshotCommand {
+    #[command(flatten)]
     pub common: CommonArgs,
+    #[arg(
+        long = "out-dir",
+        value_name = "DIR",
+        help = "output directory for generated Web snapshots (JSON + TS)",
+        value_parser = value_parser!(PathBuf),
+        default_value = "web_snapshots"
+    )]
     pub out_dir: PathBuf,
+    #[arg(
+        long = "ts-export",
+        value_name = "NAME",
+        help = "name of the exported constant in the generated TS module",
+        default_value = "SessionSnapshot"
+    )]
     pub ts_export: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
 pub struct TuiSnapshotCommand {
+    #[command(flatten)]
     pub common: CommonArgs,
+    #[arg(
+        long = "out-dir",
+        value_name = "DIR",
+        help = "output directory for generated TUI artifact modules (Rust source)",
+        value_parser = value_parser!(PathBuf),
+        default_value = "tui_artifacts"
+    )]
     pub out_dir: PathBuf,
+    #[arg(
+        long = "tui-fn",
+        value_name = "NAME",
+        help = "name of the generated TuiArtifacts constructor function",
+        default_value = "tui_artifacts"
+    )]
     pub tui_fn: String,
+    #[arg(
+        long = "form-fn",
+        value_name = "NAME",
+        help = "name of the generated FormSchema constructor function",
+        default_value = "tui_form_schema"
+    )]
     pub form_fn: String,
+    #[arg(
+        long = "layout-fn",
+        value_name = "NAME",
+        help = "name of the generated LayoutNavModel constructor function",
+        default_value = "tui_layout_nav"
+    )]
     pub layout_fn: String,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Args, Debug, Clone, Default, PartialEq, Eq)]
 pub struct CommonArgs {
+    #[arg(
+        short = 's',
+        long = "schema",
+        help = "schema spec: local path, file/HTTP URL, inline payload, or \"-\" for stdin",
+        allow_hyphen_values = true
+    )]
     pub schema: Option<String>,
+    #[arg(
+        short = 'c',
+        long = "config",
+        visible_alias = "data",
+        help = "config spec: local path, file/HTTP URL, inline payload, or \"-\" for stdin",
+        allow_hyphen_values = true
+    )]
     pub config: Option<String>,
+    #[arg(
+        long = "title",
+        help = "title shown at the top of the UI",
+        allow_hyphen_values = true
+    )]
     pub title: Option<String>,
+    #[arg(
+        long = "description",
+        help = "description shown under the title in the active UI",
+        allow_hyphen_values = true
+    )]
     pub description: Option<String>,
+    #[arg(
+        short = 'o',
+        long = "output",
+        value_name = "DEST",
+        help = "output destinations (\"-\" writes to stdout). Repeat the flag to add more",
+        action = ArgAction::Append,
+        num_args = 1..,
+        allow_hyphen_values = true
+    )]
     pub outputs: Vec<String>,
+    #[arg(
+        long = "temp-file",
+        value_name = "PATH",
+        help = "write to PATH when no destinations are set (stdout remains the default)",
+        value_parser = value_parser!(PathBuf)
+    )]
     pub temp_file: Option<PathBuf>,
+    #[arg(
+        long = "no-temp-file",
+        help = "compatibility no-op: stdout is already the default when no destinations are set",
+        action = ArgAction::SetTrue
+    )]
     pub no_temp_file: bool,
+    #[arg(
+        long = "no-pretty",
+        help = "emit compact JSON/TOML rather than pretty formatting",
+        action = ArgAction::SetTrue
+    )]
     pub no_pretty: bool,
+    #[arg(
+        short = 'f',
+        long = "force",
+        visible_short_alias = 'y',
+        visible_alias = "yes",
+        help = "overwrite output files even if they already exist",
+        action = ArgAction::SetTrue
+    )]
     pub force: bool,
 }
 
@@ -164,107 +294,12 @@ impl Cli {
         T: Into<String>,
     {
         let argv = args.into_iter().map(Into::into).collect::<Vec<_>>();
-        let matches = command_info()
-            .try_get_matches_from(argv)
-            .map_err(clap_error_to_exit)?;
-        Ok(Self::from_matches(&matches))
-    }
-
-    fn from_matches(matches: &ArgMatches) -> Self {
-        let common = common_args_from_matches(matches);
-        let command = match matches.subcommand() {
-            Some(("completion", sub_matches)) => Some(Commands::Completion(CompletionCommand {
-                shell: *sub_matches
-                    .get_one::<CompletionShell>("shell")
-                    .expect("completion shell is required"),
-            })),
-            Some(("tui", sub_matches)) => Some(Commands::Tui(TuiCommand {
-                common: common_args_from_matches(sub_matches),
-            })),
-            #[cfg(feature = "web")]
-            Some(("web", sub_matches)) => Some(Commands::Web(WebCommand {
-                common: common_args_from_matches(sub_matches),
-                host: *sub_matches
-                    .get_one::<IpAddr>("host")
-                    .expect("web host has a default"),
-                port: *sub_matches
-                    .get_one::<u16>("port")
-                    .expect("web port has a default"),
-            })),
-            #[cfg(feature = "web")]
-            Some(("web-snapshot", sub_matches)) => {
-                Some(Commands::WebSnapshot(WebSnapshotCommand {
-                    common: common_args_from_matches(sub_matches),
-                    out_dir: sub_matches
-                        .get_one::<PathBuf>("out_dir")
-                        .cloned()
-                        .expect("web snapshot out-dir has a default"),
-                    ts_export: sub_matches
-                        .get_one::<String>("ts_export")
-                        .cloned()
-                        .expect("web snapshot ts-export has a default"),
-                }))
-            }
-            Some(("tui-snapshot", sub_matches)) => {
-                Some(Commands::TuiSnapshot(TuiSnapshotCommand {
-                    common: common_args_from_matches(sub_matches),
-                    out_dir: sub_matches
-                        .get_one::<PathBuf>("out_dir")
-                        .cloned()
-                        .expect("tui snapshot out-dir has a default"),
-                    tui_fn: sub_matches
-                        .get_one::<String>("tui_fn")
-                        .cloned()
-                        .expect("tui snapshot tui-fn has a default"),
-                    form_fn: sub_matches
-                        .get_one::<String>("form_fn")
-                        .cloned()
-                        .expect("tui snapshot form-fn has a default"),
-                    layout_fn: sub_matches
-                        .get_one::<String>("layout_fn")
-                        .cloned()
-                        .expect("tui snapshot layout-fn has a default"),
-                }))
-            }
-            None => None,
-            Some((other, _)) => unreachable!("unexpected subcommand: {other}"),
-        };
-
-        Self { common, command }
+        <Self as Parser>::try_parse_from(argv).map_err(clap_error_to_exit)
     }
 }
 
 pub fn command_info() -> clap::Command {
-    let command = Command::new("schemaui")
-        .about("Render JSON Schemas as interactive TUIs or Web UIs")
-        .version(env!("CARGO_PKG_VERSION"))
-        .propagate_version(true)
-        .disable_help_subcommand(true)
-        .disable_version_flag(true)
-        .subcommand_precedence_over_arg(true)
-        .arg(version_arg());
-
-    let command = with_common_args(command)
-        .subcommand(completion_command())
-        .subcommand(tui_command())
-        .subcommand(tui_snapshot_command());
-
-    #[cfg(feature = "web")]
-    let command = command
-        .subcommand(web_command())
-        .subcommand(web_snapshot_command());
-
-    command
-}
-
-impl CommandFactory for Cli {
-    fn command() -> Command {
-        command_info()
-    }
-
-    fn command_for_update() -> Command {
-        command_info()
-    }
+    <Cli as CommandFactory>::command()
 }
 
 fn clap_error_to_exit(err: clap::Error) -> CliParseExit {
@@ -275,193 +310,4 @@ fn clap_error_to_exit(err: clap::Error) -> CliParseExit {
         }
         _ => CliParseExit::error(output),
     }
-}
-
-fn common_args_from_matches(matches: &ArgMatches) -> CommonArgs {
-    CommonArgs {
-        schema: matches.get_one::<String>("schema").cloned(),
-        config: matches.get_one::<String>("config").cloned(),
-        title: matches.get_one::<String>("title").cloned(),
-        description: matches.get_one::<String>("description").cloned(),
-        outputs: matches
-            .get_many::<String>("output")
-            .map(|values| values.cloned().collect())
-            .unwrap_or_default(),
-        temp_file: matches.get_one::<PathBuf>("temp_file").cloned(),
-        no_temp_file: matches.get_flag("no_temp_file"),
-        no_pretty: matches.get_flag("no_pretty"),
-        force: matches.get_flag("force"),
-    }
-}
-
-fn with_common_args(command: Command) -> Command {
-    common_args()
-        .into_iter()
-        .fold(command, |command, arg| command.arg(arg))
-}
-
-fn common_args() -> Vec<Arg> {
-    vec![
-        Arg::new("schema")
-            .short('s')
-            .long("schema")
-            .help("schema spec: local path, file/HTTP URL, inline payload, or \"-\" for stdin")
-            .action(ArgAction::Set)
-            .allow_hyphen_values(true),
-        Arg::new("config")
-            .short('c')
-            .long("config")
-            .visible_alias("data")
-            .help("config spec: local path, file/HTTP URL, inline payload, or \"-\" for stdin")
-            .action(ArgAction::Set)
-            .allow_hyphen_values(true),
-        Arg::new("title")
-            .long("title")
-            .help("title shown at the top of the UI")
-            .action(ArgAction::Set)
-            .allow_hyphen_values(true),
-        Arg::new("description")
-            .long("description")
-            .help("description shown under the title in the active UI")
-            .action(ArgAction::Set)
-            .allow_hyphen_values(true),
-        Arg::new("output")
-            .short('o')
-            .long("output")
-            .value_name("DEST")
-            .help("output destinations (\"-\" writes to stdout). Repeat the flag to add more")
-            .action(ArgAction::Append)
-            .num_args(1..)
-            .allow_hyphen_values(true),
-        Arg::new("temp_file")
-            .long("temp-file")
-            .value_name("PATH")
-            .help("write to PATH when no destinations are set (stdout remains the default)")
-            .value_parser(value_parser!(PathBuf)),
-        Arg::new("no_temp_file")
-            .long("no-temp-file")
-            .help("compatibility no-op: stdout is already the default when no destinations are set")
-            .action(ArgAction::SetTrue),
-        Arg::new("no_pretty")
-            .long("no-pretty")
-            .help("emit compact JSON/TOML rather than pretty formatting")
-            .action(ArgAction::SetTrue),
-        Arg::new("force")
-            .short('f')
-            .long("force")
-            .visible_short_alias('y')
-            .visible_alias("yes")
-            .help("overwrite output files even if they already exist")
-            .action(ArgAction::SetTrue),
-    ]
-}
-
-fn version_arg() -> Arg {
-    Arg::new("version_flag")
-        .long("version")
-        .short('V')
-        .visible_short_alias('v')
-        .global(true)
-        .help("Print version")
-        .action(ArgAction::Version)
-}
-
-fn completion_command() -> Command {
-    Command::new("completion")
-        .about("Generate shell completion scripts for the schemaui CLI")
-        .arg(
-            Arg::new("shell")
-                .help("target shell: bash, zsh, fish, or powershell")
-                .required(true)
-                .value_parser(EnumValueParser::<CompletionShell>::new()),
-        )
-}
-
-fn tui_command() -> Command {
-    with_common_args(Command::new("tui").about("Launch the interactive terminal UI"))
-}
-
-#[cfg(feature = "web")]
-fn web_command() -> Command {
-    with_common_args(
-        Command::new("web").about("Launch the interactive web UI instead of the terminal UI"),
-    )
-    .arg(
-        Arg::new("host")
-            .short('l')
-            .long("host")
-            .visible_aliases(["bind", "listen"])
-            .value_name("IP")
-            .help("bind address for the temporary HTTP server")
-            .value_parser(value_parser!(IpAddr))
-            .default_value("127.0.0.1"),
-    )
-    .arg(
-        Arg::new("port")
-            .short('p')
-            .long("port")
-            .value_name("PORT")
-            .help("bind port for the temporary HTTP server (0 picks a random free port)")
-            .value_parser(value_parser!(u16))
-            .default_value("0"),
-    )
-}
-
-#[cfg(feature = "web")]
-fn web_snapshot_command() -> Command {
-    with_common_args(
-        Command::new("web-snapshot")
-            .about("Precompute Web session snapshots instead of launching the UI"),
-    )
-    .arg(
-        Arg::new("out_dir")
-            .long("out-dir")
-            .value_name("DIR")
-            .help("output directory for generated Web snapshots (JSON + TS)")
-            .value_parser(value_parser!(PathBuf))
-            .default_value("web_snapshots"),
-    )
-    .arg(
-        Arg::new("ts_export")
-            .long("ts-export")
-            .value_name("NAME")
-            .help("name of the exported constant in the generated TS module")
-            .default_value("SessionSnapshot"),
-    )
-}
-
-fn tui_snapshot_command() -> Command {
-    with_common_args(
-        Command::new("tui-snapshot")
-            .about("Precompute TUI FormSchema/LayoutNavModel modules instead of launching the UI"),
-    )
-    .arg(
-        Arg::new("out_dir")
-            .long("out-dir")
-            .value_name("DIR")
-            .help("output directory for generated TUI artifact modules (Rust source)")
-            .value_parser(value_parser!(PathBuf))
-            .default_value("tui_artifacts"),
-    )
-    .arg(
-        Arg::new("tui_fn")
-            .long("tui-fn")
-            .value_name("NAME")
-            .help("name of the generated TuiArtifacts constructor function")
-            .default_value("tui_artifacts"),
-    )
-    .arg(
-        Arg::new("form_fn")
-            .long("form-fn")
-            .value_name("NAME")
-            .help("name of the generated FormSchema constructor function")
-            .default_value("tui_form_schema"),
-    )
-    .arg(
-        Arg::new("layout_fn")
-            .long("layout-fn")
-            .value_name("NAME")
-            .help("name of the generated LayoutNavModel constructor function")
-            .default_value("tui_layout_nav"),
-    )
 }

--- a/schemaui-cli/src/cli.rs
+++ b/schemaui-cli/src/cli.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
-use argh::{ArgsInfo, FromArgValue, FromArgs};
+use clap::{
+    Arg, ArgAction, ArgMatches, Command, CommandFactory, ValueEnum, builder::EnumValueParser,
+    value_parser,
+};
 
 #[cfg(feature = "web")]
 use std::net::IpAddr;
@@ -32,12 +35,16 @@ pub struct CompletionCommand {
     pub shell: CompletionShell,
 }
 
-#[derive(FromArgValue, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompletionShell {
+    #[value(name = "bash")]
     Bash,
+    #[value(name = "zsh")]
     Zsh,
+    #[value(name = "fish")]
     Fish,
-    Nushell,
+    #[value(name = "powershell")]
+    PowerShell,
 }
 
 #[cfg(feature = "web")]
@@ -100,6 +107,28 @@ impl CommonArgs {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CliParseExit {
+    pub output: String,
+    pub status: Result<(), ()>,
+}
+
+impl CliParseExit {
+    fn success(output: String) -> Self {
+        Self {
+            output,
+            status: Ok(()),
+        }
+    }
+
+    fn error(output: String) -> Self {
+        Self {
+            output,
+            status: Err(()),
+        }
+    }
+}
+
 impl Cli {
     pub fn parse() -> Self {
         Self::from_env_or_exit()
@@ -129,632 +158,310 @@ impl Cli {
         })
     }
 
-    pub fn try_parse_from<I, T>(args: I) -> Result<Self, argh::EarlyExit>
+    pub fn try_parse_from<I, T>(args: I) -> Result<Self, CliParseExit>
     where
         I: IntoIterator<Item = T>,
         T: Into<String>,
     {
-        let raw = args.into_iter().map(Into::into).collect::<Vec<_>>();
-        let program = raw
-            .first()
-            .cloned()
-            .unwrap_or_else(|| "schemaui".to_string());
-
-        let normalized = normalize_args(&raw[1..]);
-        let scan = scan_for_command(&normalized);
-        let mut parse_args = normalized.clone();
-        let injected_default_tui = matches!(scan, CommandScan::None);
-        if injected_default_tui {
-            parse_args.push("tui".to_string());
-        }
-        let parse_args = expand_output_values(&parse_args);
-        let parse_refs = parse_args.iter().map(String::as_str).collect::<Vec<_>>();
-        let parsed = ArghCli::from_args(&[program.as_str()], &parse_refs)?;
-        Ok(Self::from_argh(parsed, injected_default_tui))
+        let argv = args.into_iter().map(Into::into).collect::<Vec<_>>();
+        let matches = command_info()
+            .try_get_matches_from(argv)
+            .map_err(clap_error_to_exit)?;
+        Ok(Self::from_matches(&matches))
     }
 
-    fn from_argh(parsed: ArghCli, injected_default_tui: bool) -> Self {
-        let common = common_args_from_root(&parsed);
-        match parsed.command {
-            ArghCommands::Tui(_command) if injected_default_tui => Self {
-                common,
-                command: None,
-            },
-            ArghCommands::Completion(command) => Self {
-                common,
-                command: Some(Commands::Completion(CompletionCommand {
-                    shell: command.shell,
-                })),
-            },
-            ArghCommands::Tui(command) => Self {
-                common,
-                command: Some(Commands::Tui(TuiCommand {
-                    common: common_args_from_tui(command),
-                })),
-            },
+    fn from_matches(matches: &ArgMatches) -> Self {
+        let common = common_args_from_matches(matches);
+        let command = match matches.subcommand() {
+            Some(("completion", sub_matches)) => Some(Commands::Completion(CompletionCommand {
+                shell: *sub_matches
+                    .get_one::<CompletionShell>("shell")
+                    .expect("completion shell is required"),
+            })),
+            Some(("tui", sub_matches)) => Some(Commands::Tui(TuiCommand {
+                common: common_args_from_matches(sub_matches),
+            })),
             #[cfg(feature = "web")]
-            ArghCommands::Web(command) => Self {
-                common,
-                command: Some(Commands::Web(WebCommand {
-                    common: common_args_from_web(&command),
-                    host: command.host,
-                    port: command.port,
-                })),
-            },
+            Some(("web", sub_matches)) => Some(Commands::Web(WebCommand {
+                common: common_args_from_matches(sub_matches),
+                host: *sub_matches
+                    .get_one::<IpAddr>("host")
+                    .expect("web host has a default"),
+                port: *sub_matches
+                    .get_one::<u16>("port")
+                    .expect("web port has a default"),
+            })),
             #[cfg(feature = "web")]
-            ArghCommands::WebSnapshot(command) => Self {
-                common,
-                command: Some(Commands::WebSnapshot(WebSnapshotCommand {
-                    common: common_args_from_web_snapshot(&command),
-                    out_dir: command.out_dir,
-                    ts_export: command.ts_export,
-                })),
-            },
-            ArghCommands::TuiSnapshot(command) => Self {
-                common,
-                command: Some(Commands::TuiSnapshot(TuiSnapshotCommand {
-                    common: common_args_from_tui_snapshot(&command),
-                    out_dir: command.out_dir,
-                    tui_fn: command.tui_fn,
-                    form_fn: command.form_fn,
-                    layout_fn: command.layout_fn,
-                })),
-            },
-        }
-    }
-}
-
-pub fn command_info() -> argh::CommandInfoWithArgs {
-    ArghCli::get_args_info()
-}
-
-fn common_args_from_root(args: &ArghCli) -> CommonArgs {
-    CommonArgs {
-        schema: args.schema.clone(),
-        config: args.config.clone(),
-        title: args.title.clone(),
-        description: args.description.clone(),
-        outputs: args.outputs.clone(),
-        temp_file: args.temp_file.clone(),
-        no_temp_file: args.no_temp_file,
-        no_pretty: args.no_pretty,
-        force: args.force,
-    }
-}
-
-fn common_args_from_tui(args: ArghTuiCommand) -> CommonArgs {
-    CommonArgs {
-        schema: args.schema,
-        config: args.config,
-        title: args.title,
-        description: args.description,
-        outputs: args.outputs,
-        temp_file: args.temp_file,
-        no_temp_file: args.no_temp_file,
-        no_pretty: args.no_pretty,
-        force: args.force,
-    }
-}
-
-#[cfg(feature = "web")]
-fn common_args_from_web(args: &ArghWebCommand) -> CommonArgs {
-    CommonArgs {
-        schema: args.schema.clone(),
-        config: args.config.clone(),
-        title: args.title.clone(),
-        description: args.description.clone(),
-        outputs: args.outputs.clone(),
-        temp_file: args.temp_file.clone(),
-        no_temp_file: args.no_temp_file,
-        no_pretty: args.no_pretty,
-        force: args.force,
-    }
-}
-
-#[cfg(feature = "web")]
-fn common_args_from_web_snapshot(args: &ArghWebSnapshotCommand) -> CommonArgs {
-    CommonArgs {
-        schema: args.schema.clone(),
-        config: args.config.clone(),
-        title: args.title.clone(),
-        description: args.description.clone(),
-        outputs: args.outputs.clone(),
-        temp_file: args.temp_file.clone(),
-        no_temp_file: args.no_temp_file,
-        no_pretty: args.no_pretty,
-        force: args.force,
-    }
-}
-
-fn common_args_from_tui_snapshot(args: &ArghTuiSnapshotCommand) -> CommonArgs {
-    CommonArgs {
-        schema: args.schema.clone(),
-        config: args.config.clone(),
-        title: args.title.clone(),
-        description: args.description.clone(),
-        outputs: args.outputs.clone(),
-        temp_file: args.temp_file.clone(),
-        no_temp_file: args.no_temp_file,
-        no_pretty: args.no_pretty,
-        force: args.force,
-    }
-}
-
-#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
-#[argh(help_triggers("-h", "--help", "help"))]
-/// Render JSON Schemas as interactive TUIs or Web UIs
-struct ArghCli {
-    /// schema spec: local path, file/HTTP URL, inline payload, or "-" for stdin
-    #[argh(option, short = 's')]
-    schema: Option<String>,
-
-    /// config spec: local path, file/HTTP URL, inline payload, or "-" for stdin
-    #[argh(option, short = 'c')]
-    config: Option<String>,
-
-    /// title shown at the top of the UI
-    #[argh(option)]
-    title: Option<String>,
-
-    /// description shown under the title in the active UI
-    #[argh(option)]
-    description: Option<String>,
-
-    /// output destinations ("-" writes to stdout). Repeat the flag to add more.
-    #[argh(option, short = 'o', long = "output")]
-    outputs: Vec<String>,
-
-    /// write to PATH when no destinations are set (stdout remains the default)
-    #[argh(option)]
-    temp_file: Option<PathBuf>,
-
-    /// compatibility no-op: stdout is already the default when no destinations are set
-    #[argh(switch)]
-    no_temp_file: bool,
-
-    /// emit compact JSON/TOML rather than pretty formatting
-    #[argh(switch)]
-    no_pretty: bool,
-
-    /// overwrite output files even if they already exist
-    #[argh(switch, short = 'f')]
-    force: bool,
-
-    #[argh(subcommand)]
-    command: ArghCommands,
-}
-
-#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
-#[argh(subcommand)]
-enum ArghCommands {
-    Completion(ArghCompletionCommand),
-    Tui(ArghTuiCommand),
-    #[cfg(feature = "web")]
-    Web(ArghWebCommand),
-    #[cfg(feature = "web")]
-    WebSnapshot(ArghWebSnapshotCommand),
-    TuiSnapshot(ArghTuiSnapshotCommand),
-}
-
-#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
-/// Generate shell completion scripts for the schemaui CLI
-#[argh(subcommand, name = "completion", help_triggers("-h", "--help", "help"))]
-struct ArghCompletionCommand {
-    /// target shell: bash, zsh, fish, or nushell
-    #[argh(positional)]
-    shell: CompletionShell,
-}
-
-#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
-#[argh(subcommand, name = "tui", help_triggers("-h", "--help", "help"))]
-/// Launch the interactive terminal UI
-struct ArghTuiCommand {
-    /// schema spec: local path, file/HTTP URL, inline payload, or "-" for stdin
-    #[argh(option, short = 's')]
-    schema: Option<String>,
-
-    /// config spec: local path, file/HTTP URL, inline payload, or "-" for stdin
-    #[argh(option, short = 'c')]
-    config: Option<String>,
-
-    /// title shown at the top of the UI
-    #[argh(option)]
-    title: Option<String>,
-
-    /// description shown under the title in the active UI
-    #[argh(option)]
-    description: Option<String>,
-
-    /// output destinations ("-" writes to stdout). Repeat the flag to add more.
-    #[argh(option, short = 'o', long = "output")]
-    outputs: Vec<String>,
-
-    /// write to PATH when no destinations are set (stdout remains the default)
-    #[argh(option)]
-    temp_file: Option<PathBuf>,
-
-    /// compatibility no-op: stdout is already the default when no destinations are set
-    #[argh(switch)]
-    no_temp_file: bool,
-
-    /// emit compact JSON/TOML rather than pretty formatting
-    #[argh(switch)]
-    no_pretty: bool,
-
-    /// overwrite output files even if they already exist
-    #[argh(switch, short = 'f')]
-    force: bool,
-}
-
-#[cfg(feature = "web")]
-#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
-#[argh(subcommand, name = "web", help_triggers("-h", "--help", "help"))]
-/// Launch the interactive web UI instead of the terminal UI
-struct ArghWebCommand {
-    /// schema spec: local path, file/HTTP URL, inline payload, or "-" for stdin
-    #[argh(option, short = 's')]
-    schema: Option<String>,
-
-    /// config spec: local path, file/HTTP URL, inline payload, or "-" for stdin
-    #[argh(option, short = 'c')]
-    config: Option<String>,
-
-    /// title shown at the top of the UI
-    #[argh(option)]
-    title: Option<String>,
-
-    /// description shown under the title in the active UI
-    #[argh(option)]
-    description: Option<String>,
-
-    /// output destinations ("-" writes to stdout). Repeat the flag to add more.
-    #[argh(option, short = 'o', long = "output")]
-    outputs: Vec<String>,
-
-    /// write to PATH when no destinations are set (stdout remains the default)
-    #[argh(option)]
-    temp_file: Option<PathBuf>,
-
-    /// compatibility no-op: stdout is already the default when no destinations are set
-    #[argh(switch)]
-    no_temp_file: bool,
-
-    /// emit compact JSON/TOML rather than pretty formatting
-    #[argh(switch)]
-    no_pretty: bool,
-
-    /// overwrite output files even if they already exist
-    #[argh(switch, short = 'f')]
-    force: bool,
-
-    /// bind address for the temporary HTTP server
-    #[argh(option, short = 'l', default = "default_host()")]
-    host: IpAddr,
-
-    /// bind port for the temporary HTTP server (0 picks a random free port)
-    #[argh(option, short = 'p', default = "0")]
-    port: u16,
-}
-
-#[cfg(feature = "web")]
-#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
-#[argh(
-    subcommand,
-    name = "web-snapshot",
-    help_triggers("-h", "--help", "help")
-)]
-/// Precompute Web session snapshots instead of launching the UI
-struct ArghWebSnapshotCommand {
-    /// schema spec: local path, file/HTTP URL, inline payload, or "-" for stdin
-    #[argh(option, short = 's')]
-    schema: Option<String>,
-
-    /// config spec: local path, file/HTTP URL, inline payload, or "-" for stdin
-    #[argh(option, short = 'c')]
-    config: Option<String>,
-
-    /// title shown at the top of the UI
-    #[argh(option)]
-    title: Option<String>,
-
-    /// description shown under the title in the active UI
-    #[argh(option)]
-    description: Option<String>,
-
-    /// output destinations ("-" writes to stdout). Repeat the flag to add more.
-    #[argh(option, short = 'o', long = "output")]
-    outputs: Vec<String>,
-
-    /// write to PATH when no destinations are set (stdout remains the default)
-    #[argh(option)]
-    temp_file: Option<PathBuf>,
-
-    /// compatibility no-op: stdout is already the default when no destinations are set
-    #[argh(switch)]
-    no_temp_file: bool,
-
-    /// emit compact JSON/TOML rather than pretty formatting
-    #[argh(switch)]
-    no_pretty: bool,
-
-    /// overwrite output files even if they already exist
-    #[argh(switch, short = 'f')]
-    force: bool,
-
-    /// output directory for generated Web snapshots (JSON + TS)
-    #[argh(option, default = "PathBuf::from(\"web_snapshots\")")]
-    out_dir: PathBuf,
-
-    /// name of the exported constant in the generated TS module
-    #[argh(option, default = "String::from(\"SessionSnapshot\")")]
-    ts_export: String,
-}
-
-#[derive(FromArgs, ArgsInfo, Debug, PartialEq)]
-#[argh(
-    subcommand,
-    name = "tui-snapshot",
-    help_triggers("-h", "--help", "help")
-)]
-/// Precompute TUI FormSchema/LayoutNavModel modules instead of launching the UI
-struct ArghTuiSnapshotCommand {
-    /// schema spec: local path, file/HTTP URL, inline payload, or "-" for stdin
-    #[argh(option, short = 's')]
-    schema: Option<String>,
-
-    /// config spec: local path, file/HTTP URL, inline payload, or "-" for stdin
-    #[argh(option, short = 'c')]
-    config: Option<String>,
-
-    /// title shown at the top of the UI
-    #[argh(option)]
-    title: Option<String>,
-
-    /// description shown under the title in the active UI
-    #[argh(option)]
-    description: Option<String>,
-
-    /// output destinations ("-" writes to stdout). Repeat the flag to add more.
-    #[argh(option, short = 'o', long = "output")]
-    outputs: Vec<String>,
-
-    /// write to PATH when no destinations are set (stdout remains the default)
-    #[argh(option)]
-    temp_file: Option<PathBuf>,
-
-    /// compatibility no-op: stdout is already the default when no destinations are set
-    #[argh(switch)]
-    no_temp_file: bool,
-
-    /// emit compact JSON/TOML rather than pretty formatting
-    #[argh(switch)]
-    no_pretty: bool,
-
-    /// overwrite output files even if they already exist
-    #[argh(switch, short = 'f')]
-    force: bool,
-
-    /// output directory for generated TUI artifact modules (Rust source)
-    #[argh(option, default = "PathBuf::from(\"tui_artifacts\")")]
-    out_dir: PathBuf,
-
-    /// name of the generated TuiArtifacts constructor function
-    #[argh(option, default = "String::from(\"tui_artifacts\")")]
-    tui_fn: String,
-
-    /// name of the generated FormSchema constructor function
-    #[argh(option, default = "String::from(\"tui_form_schema\")")]
-    form_fn: String,
-
-    /// name of the generated LayoutNavModel constructor function
-    #[argh(option, default = "String::from(\"tui_layout_nav\")")]
-    layout_fn: String,
-}
-
-#[cfg(feature = "web")]
-fn default_host() -> IpAddr {
-    IpAddr::from([127, 0, 0, 1])
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CommandScan {
-    None,
-    Help,
-    Explicit,
-}
-
-fn scan_for_command(args: &[String]) -> CommandScan {
-    let mut index = 0usize;
-    while index < args.len() {
-        let token = args[index].as_str();
-        if is_help_trigger(token) {
-            return CommandScan::Help;
-        }
-        if is_known_subcommand(token) {
-            return CommandScan::Explicit;
-        }
-        if consumes_multiple_values(token) {
-            index += 1;
-            while index < args.len() {
-                let next = args[index].as_str();
-                if next.starts_with('-') || is_known_subcommand(next) || is_help_trigger(next) {
-                    break;
-                }
-                index += 1;
+            Some(("web-snapshot", sub_matches)) => {
+                Some(Commands::WebSnapshot(WebSnapshotCommand {
+                    common: common_args_from_matches(sub_matches),
+                    out_dir: sub_matches
+                        .get_one::<PathBuf>("out_dir")
+                        .cloned()
+                        .expect("web snapshot out-dir has a default"),
+                    ts_export: sub_matches
+                        .get_one::<String>("ts_export")
+                        .cloned()
+                        .expect("web snapshot ts-export has a default"),
+                }))
             }
-            continue;
-        }
-        if consumes_single_value(token) {
-            index += 2;
-            continue;
-        }
-        index += 1;
-    }
-    CommandScan::None
-}
-
-fn normalize_args(args: &[String]) -> Vec<String> {
-    let mut normalized = Vec::new();
-    let mut index = 0usize;
-    let mut segment_start = 0usize;
-
-    while index < args.len() {
-        let token = args[index].as_str();
-
-        if let Some((flag, value)) = normalize_inline_option(token) {
-            if consumes_single_value(&flag) {
-                upsert_single_value_option(&mut normalized, segment_start, flag, value);
-            } else {
-                normalized.push(flag);
-                normalized.push(value);
+            Some(("tui-snapshot", sub_matches)) => {
+                Some(Commands::TuiSnapshot(TuiSnapshotCommand {
+                    common: common_args_from_matches(sub_matches),
+                    out_dir: sub_matches
+                        .get_one::<PathBuf>("out_dir")
+                        .cloned()
+                        .expect("tui snapshot out-dir has a default"),
+                    tui_fn: sub_matches
+                        .get_one::<String>("tui_fn")
+                        .cloned()
+                        .expect("tui snapshot tui-fn has a default"),
+                    form_fn: sub_matches
+                        .get_one::<String>("form_fn")
+                        .cloned()
+                        .expect("tui snapshot form-fn has a default"),
+                    layout_fn: sub_matches
+                        .get_one::<String>("layout_fn")
+                        .cloned()
+                        .expect("tui snapshot layout-fn has a default"),
+                }))
             }
-            index += 1;
-            continue;
-        }
-
-        let token = match token {
-            "--data" => "--config",
-            "--bind" | "--listen" => "--host",
-            "-y" | "--yes" => "--force",
-            other => other,
+            None => None,
+            Some((other, _)) => unreachable!("unexpected subcommand: {other}"),
         };
 
-        if is_known_subcommand(token) {
-            normalized.push(token.to_string());
-            segment_start = normalized.len();
-            index += 1;
-            continue;
-        }
-
-        if consumes_single_value(token)
-            && let Some(value) = args.get(index + 1)
-        {
-            upsert_single_value_option(
-                &mut normalized,
-                segment_start,
-                token.to_string(),
-                value.clone(),
-            );
-            index += 2;
-            continue;
-        }
-
-        normalized.push(token.to_string());
-        index += 1;
+        Self { common, command }
     }
-
-    normalized
 }
 
-fn upsert_single_value_option(
-    normalized: &mut Vec<String>,
-    segment_start: usize,
-    flag: String,
-    value: String,
-) {
-    if let Some(position) = normalized[segment_start..]
-        .windows(2)
-        .position(|window| window[0] == flag)
-    {
-        normalized[segment_start + position + 1] = value;
-        return;
-    }
+pub fn command_info() -> clap::Command {
+    let command = Command::new("schemaui")
+        .about("Render JSON Schemas as interactive TUIs or Web UIs")
+        .version(env!("CARGO_PKG_VERSION"))
+        .propagate_version(true)
+        .disable_help_subcommand(true)
+        .disable_version_flag(true)
+        .subcommand_precedence_over_arg(true)
+        .arg(version_arg());
 
-    normalized.push(flag);
-    normalized.push(value);
+    let command = with_common_args(command)
+        .subcommand(completion_command())
+        .subcommand(tui_command())
+        .subcommand(tui_snapshot_command());
+
+    #[cfg(feature = "web")]
+    let command = command
+        .subcommand(web_command())
+        .subcommand(web_snapshot_command());
+
+    command
 }
 
-fn normalize_inline_option(token: &str) -> Option<(String, String)> {
-    const INLINE_ALIASES: &[(&str, &str)] = &[
-        ("--schema=", "--schema"),
-        ("--config=", "--config"),
-        ("--data=", "--config"),
-        ("--title=", "--title"),
-        ("--description=", "--description"),
-        ("--output=", "--output"),
-        ("--temp-file=", "--temp-file"),
-        ("--host=", "--host"),
-        ("--bind=", "--host"),
-        ("--listen=", "--host"),
-        ("--port=", "--port"),
-        ("--out-dir=", "--out-dir"),
-        ("--tui-fn=", "--tui-fn"),
-        ("--form-fn=", "--form-fn"),
-        ("--layout-fn=", "--layout-fn"),
-        ("--ts-export=", "--ts-export"),
-    ];
+impl CommandFactory for Cli {
+    fn command() -> Command {
+        command_info()
+    }
 
-    for (prefix, canonical) in INLINE_ALIASES {
-        if let Some(value) = token.strip_prefix(prefix) {
-            return Some(((*canonical).to_string(), value.to_string()));
+    fn command_for_update() -> Command {
+        command_info()
+    }
+}
+
+fn clap_error_to_exit(err: clap::Error) -> CliParseExit {
+    let output = err.to_string();
+    match err.kind() {
+        clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => {
+            CliParseExit::success(output)
         }
+        _ => CliParseExit::error(output),
     }
-    None
 }
 
-fn expand_output_values(args: &[String]) -> Vec<String> {
-    let mut expanded = Vec::new();
-    let mut index = 0usize;
-    while index < args.len() {
-        let token = args[index].as_str();
-        if consumes_multiple_values(token) {
-            let canonical = "--output".to_string();
-            expanded.push(canonical.clone());
-            index += 1;
-
-            let mut consumed_any = false;
-            while index < args.len() {
-                let next = args[index].as_str();
-                if next.starts_with('-') || is_known_subcommand(next) {
-                    break;
-                }
-
-                if consumed_any {
-                    expanded.push(canonical.clone());
-                }
-                expanded.push(args[index].clone());
-                consumed_any = true;
-                index += 1;
-            }
-            continue;
-        }
-
-        expanded.push(args[index].clone());
-        index += 1;
+fn common_args_from_matches(matches: &ArgMatches) -> CommonArgs {
+    CommonArgs {
+        schema: matches.get_one::<String>("schema").cloned(),
+        config: matches.get_one::<String>("config").cloned(),
+        title: matches.get_one::<String>("title").cloned(),
+        description: matches.get_one::<String>("description").cloned(),
+        outputs: matches
+            .get_many::<String>("output")
+            .map(|values| values.cloned().collect())
+            .unwrap_or_default(),
+        temp_file: matches.get_one::<PathBuf>("temp_file").cloned(),
+        no_temp_file: matches.get_flag("no_temp_file"),
+        no_pretty: matches.get_flag("no_pretty"),
+        force: matches.get_flag("force"),
     }
-    expanded
 }
 
-fn consumes_single_value(token: &str) -> bool {
-    matches!(
-        token,
-        "-s" | "--schema"
-            | "-c"
-            | "--config"
-            | "--title"
-            | "--description"
-            | "--temp-file"
-            | "-l"
-            | "--host"
-            | "-p"
-            | "--port"
-            | "--out-dir"
-            | "--tui-fn"
-            | "--form-fn"
-            | "--layout-fn"
-            | "--ts-export"
+fn with_common_args(command: Command) -> Command {
+    common_args()
+        .into_iter()
+        .fold(command, |command, arg| command.arg(arg))
+}
+
+fn common_args() -> Vec<Arg> {
+    vec![
+        Arg::new("schema")
+            .short('s')
+            .long("schema")
+            .help("schema spec: local path, file/HTTP URL, inline payload, or \"-\" for stdin")
+            .action(ArgAction::Set)
+            .allow_hyphen_values(true),
+        Arg::new("config")
+            .short('c')
+            .long("config")
+            .visible_alias("data")
+            .help("config spec: local path, file/HTTP URL, inline payload, or \"-\" for stdin")
+            .action(ArgAction::Set)
+            .allow_hyphen_values(true),
+        Arg::new("title")
+            .long("title")
+            .help("title shown at the top of the UI")
+            .action(ArgAction::Set)
+            .allow_hyphen_values(true),
+        Arg::new("description")
+            .long("description")
+            .help("description shown under the title in the active UI")
+            .action(ArgAction::Set)
+            .allow_hyphen_values(true),
+        Arg::new("output")
+            .short('o')
+            .long("output")
+            .value_name("DEST")
+            .help("output destinations (\"-\" writes to stdout). Repeat the flag to add more")
+            .action(ArgAction::Append)
+            .num_args(1..)
+            .allow_hyphen_values(true),
+        Arg::new("temp_file")
+            .long("temp-file")
+            .value_name("PATH")
+            .help("write to PATH when no destinations are set (stdout remains the default)")
+            .value_parser(value_parser!(PathBuf)),
+        Arg::new("no_temp_file")
+            .long("no-temp-file")
+            .help("compatibility no-op: stdout is already the default when no destinations are set")
+            .action(ArgAction::SetTrue),
+        Arg::new("no_pretty")
+            .long("no-pretty")
+            .help("emit compact JSON/TOML rather than pretty formatting")
+            .action(ArgAction::SetTrue),
+        Arg::new("force")
+            .short('f')
+            .long("force")
+            .visible_short_alias('y')
+            .visible_alias("yes")
+            .help("overwrite output files even if they already exist")
+            .action(ArgAction::SetTrue),
+    ]
+}
+
+fn version_arg() -> Arg {
+    Arg::new("version_flag")
+        .long("version")
+        .short('V')
+        .visible_short_alias('v')
+        .global(true)
+        .help("Print version")
+        .action(ArgAction::Version)
+}
+
+fn completion_command() -> Command {
+    Command::new("completion")
+        .about("Generate shell completion scripts for the schemaui CLI")
+        .arg(
+            Arg::new("shell")
+                .help("target shell: bash, zsh, fish, or powershell")
+                .required(true)
+                .value_parser(EnumValueParser::<CompletionShell>::new()),
+        )
+}
+
+fn tui_command() -> Command {
+    with_common_args(Command::new("tui").about("Launch the interactive terminal UI"))
+}
+
+#[cfg(feature = "web")]
+fn web_command() -> Command {
+    with_common_args(
+        Command::new("web").about("Launch the interactive web UI instead of the terminal UI"),
+    )
+    .arg(
+        Arg::new("host")
+            .short('l')
+            .long("host")
+            .visible_aliases(["bind", "listen"])
+            .value_name("IP")
+            .help("bind address for the temporary HTTP server")
+            .value_parser(value_parser!(IpAddr))
+            .default_value("127.0.0.1"),
+    )
+    .arg(
+        Arg::new("port")
+            .short('p')
+            .long("port")
+            .value_name("PORT")
+            .help("bind port for the temporary HTTP server (0 picks a random free port)")
+            .value_parser(value_parser!(u16))
+            .default_value("0"),
     )
 }
 
-fn consumes_multiple_values(token: &str) -> bool {
-    matches!(token, "-o" | "--output")
+#[cfg(feature = "web")]
+fn web_snapshot_command() -> Command {
+    with_common_args(
+        Command::new("web-snapshot")
+            .about("Precompute Web session snapshots instead of launching the UI"),
+    )
+    .arg(
+        Arg::new("out_dir")
+            .long("out-dir")
+            .value_name("DIR")
+            .help("output directory for generated Web snapshots (JSON + TS)")
+            .value_parser(value_parser!(PathBuf))
+            .default_value("web_snapshots"),
+    )
+    .arg(
+        Arg::new("ts_export")
+            .long("ts-export")
+            .value_name("NAME")
+            .help("name of the exported constant in the generated TS module")
+            .default_value("SessionSnapshot"),
+    )
 }
 
-fn is_help_trigger(token: &str) -> bool {
-    matches!(token, "-h" | "--help" | "help")
-}
-
-fn is_known_subcommand(token: &str) -> bool {
-    matches!(token, "completion" | "tui" | "tui-snapshot")
-        || cfg!(feature = "web") && matches!(token, "web" | "web-snapshot")
+fn tui_snapshot_command() -> Command {
+    with_common_args(
+        Command::new("tui-snapshot")
+            .about("Precompute TUI FormSchema/LayoutNavModel modules instead of launching the UI"),
+    )
+    .arg(
+        Arg::new("out_dir")
+            .long("out-dir")
+            .value_name("DIR")
+            .help("output directory for generated TUI artifact modules (Rust source)")
+            .value_parser(value_parser!(PathBuf))
+            .default_value("tui_artifacts"),
+    )
+    .arg(
+        Arg::new("tui_fn")
+            .long("tui-fn")
+            .value_name("NAME")
+            .help("name of the generated TuiArtifacts constructor function")
+            .default_value("tui_artifacts"),
+    )
+    .arg(
+        Arg::new("form_fn")
+            .long("form-fn")
+            .value_name("NAME")
+            .help("name of the generated FormSchema constructor function")
+            .default_value("tui_form_schema"),
+    )
+    .arg(
+        Arg::new("layout_fn")
+            .long("layout-fn")
+            .value_name("NAME")
+            .help("name of the generated LayoutNavModel constructor function")
+            .default_value("tui_layout_nav"),
+    )
 }

--- a/schemaui-cli/src/completion.rs
+++ b/schemaui-cli/src/completion.rs
@@ -1,20 +1,25 @@
 use std::path::Path;
 
-use argh_complete::Generator;
+use clap_complete::{Shell, generate};
 use color_eyre::eyre::Result;
 
 use crate::cli::{CompletionCommand, CompletionShell, command_info};
 
 pub fn render_script(shell: CompletionShell) -> String {
     let command_name = command_name();
-    let info = command_info();
+    let mut command = command_info();
+    let mut bytes = Vec::new();
 
     match shell {
-        CompletionShell::Bash => argh_complete::bash::Bash::generate(&command_name, &info),
-        CompletionShell::Zsh => argh_complete::zsh::Zsh::generate(&command_name, &info),
-        CompletionShell::Fish => argh_complete::fish::Fish::generate(&command_name, &info),
-        CompletionShell::Nushell => argh_complete::nushell::Nushell::generate(&command_name, &info),
+        CompletionShell::Bash => generate(Shell::Bash, &mut command, command_name, &mut bytes),
+        CompletionShell::Zsh => generate(Shell::Zsh, &mut command, command_name, &mut bytes),
+        CompletionShell::Fish => generate(Shell::Fish, &mut command, command_name, &mut bytes),
+        CompletionShell::PowerShell => {
+            generate(Shell::PowerShell, &mut command, command_name, &mut bytes)
+        }
     }
+
+    String::from_utf8(bytes).expect("completion script should be utf-8")
 }
 
 pub fn run_cli(args: CompletionCommand) -> Result<()> {

--- a/schemaui-cli/tests/arg_order.rs
+++ b/schemaui-cli/tests/arg_order.rs
@@ -157,21 +157,16 @@ fn trailing_web_token_is_parsed_as_subcommand_after_root_args() {
 
 #[cfg(feature = "web")]
 #[test]
-fn web_host_aliases_are_normalized_before_parsing() {
-    let cli = Cli::parse_from([
-        "schemaui",
-        "web",
-        "--bind",
-        "0.0.0.0",
-        "--listen",
-        "127.0.0.1",
-    ]);
+fn web_host_aliases_parse_as_host() {
+    for (flag, expected) in [("--bind", "0.0.0.0"), ("--listen", "127.0.0.1")] {
+        let cli = Cli::parse_from(["schemaui", "web", flag, expected]);
 
-    let Some(Commands::Web(cmd)) = cli.command else {
-        panic!("expected explicit web subcommand");
-    };
+        let Some(Commands::Web(cmd)) = cli.command else {
+            panic!("expected explicit web subcommand");
+        };
 
-    assert_eq!(cmd.host.to_string(), "127.0.0.1");
+        assert_eq!(cmd.host.to_string(), expected);
+    }
 }
 
 #[cfg(feature = "web")]
@@ -192,4 +187,26 @@ fn explicit_web_snapshot_subcommand_accepts_common_args() {
 
     assert_eq!(cmd.common.schema.as_deref(), Some("./schema.json"));
     assert_eq!(cmd.out_dir.to_str(), Some("./snapshots"));
+}
+
+#[test]
+fn version_flags_are_normalized_before_parsing() {
+    for flag in ["--version", "-V", "-v"] {
+        let exit = Cli::try_parse_from(["schemaui", flag])
+            .expect_err("version should short-circuit parsing");
+        assert!(exit.status.is_ok(), "{flag} should exit successfully");
+        assert!(
+            exit.output.contains(env!("CARGO_PKG_VERSION")),
+            "{flag} output should include package version: {}",
+            exit.output
+        );
+    }
+}
+
+#[test]
+fn version_like_option_values_do_not_trigger_version_exit() {
+    let cli = Cli::parse_from(["schemaui", "--title", "-v"]);
+
+    assert!(cli.command.is_none(), "expected implicit default TUI mode");
+    assert_eq!(cli.common.title.as_deref(), Some("-v"));
 }

--- a/schemaui-cli/tests/arg_order.rs
+++ b/schemaui-cli/tests/arg_order.rs
@@ -24,7 +24,7 @@ fn default_tui_accepts_description_flag() {
 }
 
 #[test]
-fn inline_description_assignment_is_normalized_before_parsing() {
+fn inline_description_assignment_is_parsed_by_clap() {
     let cli = Cli::parse_from([
         "schemaui",
         "--schema=./schema.json",
@@ -72,7 +72,7 @@ fn subcommand_description_overrides_root_description_during_merge() {
 }
 
 #[test]
-fn explicit_completion_subcommand_is_not_rewritten_to_default_tui() {
+fn explicit_completion_subcommand_remains_completion() {
     let cli = Cli::parse_from(["schemaui", "completion", "bash"]);
 
     let Some(Commands::Completion(cmd)) = cli.command else {
@@ -102,7 +102,7 @@ fn explicit_tui_snapshot_subcommand_accepts_common_args() {
 }
 
 #[test]
-fn alias_flags_are_normalized_before_parsing() {
+fn alias_flags_are_parsed_by_clap() {
     let cli = Cli::parse_from([
         "schemaui",
         "--data",
@@ -190,8 +190,8 @@ fn explicit_web_snapshot_subcommand_accepts_common_args() {
 }
 
 #[test]
-fn version_flags_are_normalized_before_parsing() {
-    for flag in ["--version", "-V", "-v"] {
+fn version_flags_short_circuit_parsing() {
+    for flag in ["--version", "-V"] {
         let exit = Cli::try_parse_from(["schemaui", flag])
             .expect_err("version should short-circuit parsing");
         assert!(exit.status.is_ok(), "{flag} should exit successfully");
@@ -204,7 +204,22 @@ fn version_flags_are_normalized_before_parsing() {
 }
 
 #[test]
-fn version_like_option_values_do_not_trigger_version_exit() {
+fn bare_lowercase_v_is_not_a_version_alias() {
+    let exit = Cli::try_parse_from(["schemaui", "-v"]).expect_err("-v should fail to parse");
+
+    assert!(
+        exit.status.is_err(),
+        "-v should be treated as an unknown flag"
+    );
+    assert!(
+        exit.output.contains("unexpected argument '-v'"),
+        "unexpected output: {}",
+        exit.output
+    );
+}
+
+#[test]
+fn hyphen_prefixed_option_values_are_allowed_for_title() {
     let cli = Cli::parse_from(["schemaui", "--title", "-v"]);
 
     assert!(cli.command.is_none(), "expected implicit default TUI mode");

--- a/schemaui-cli/tests/help.rs
+++ b/schemaui-cli/tests/help.rs
@@ -10,3 +10,12 @@ fn prints_help() {
         .stdout(contains("schemaui"))
         .stdout(contains("--description"));
 }
+
+#[test]
+fn prints_version() {
+    let mut cmd = cargo::cargo_bin_cmd!("schemaui");
+    cmd.arg("--version")
+        .assert()
+        .success()
+        .stdout(contains(env!("CARGO_PKG_VERSION")));
+}


### PR DESCRIPTION
Closes #108

## Summary

This PR restores CLI version output while keeping the parser implementation simple and maintainable.

Instead of keeping a builder-heavy command tree or reintroducing manual argv normalization, the CLI is now defined primarily with
`clap` derive types.

### What changed

- switch `schemaui-cli` command definitions back to a derive-first structure
- keep clap-native version flags:
  - `--version`
  - `-V`
- intentionally do **not** support `-v` as a custom version alias
- remove the need for hand-written argv normalization logic
- keep existing useful aliases:
  - `--data` -> `--config`
  - `--yes` / `-y` -> `--force`
  - `--bind` / `--listen` -> `--host`

## Reproduction

### Before

Version output regressed after the CLI parser change.

Examples:

```bash
cargo run -p schemaui-cli --all-features -- --version
cargo run -p schemaui-cli --all-features -- -V
```

Before this fix, the CLI version flow was broken and the implementation was moving toward more custom parsing behavior than
necessary.

### After

After this fix:

```bash
cargo run -p schemaui-cli --all-features -- --version
cargo run -p schemaui-cli --all-features -- -V
```

both work again.

Also:

- bare -v is not treated as a version alias
- hyphen-prefixed values like --title -v are still parsed as values where allowed
- the CLI structure is now easier to read because options live next to their derive structs

## Why this shape

This keeps the implementation aligned with clap’s native behavior instead of maintaining custom token-rewrite logic.

So the result is:

- no normalize_version_aliases(...)
- no hand-maintained “which option consumes a value” tables
- no large builder-only command assembly for static CLI structure
- derive-first command definitions that are easier to maintain

## Size check

Release binary size was rechecked:

- main / argh: 8214208 bytes
- this clap branch: 8430208 bytes

Delta:

- +216000 bytes
- about +2.63%

So the clap version is slightly larger, but still close enough to keep the better ergonomics and feature set.

## Tests

Updated / added regression coverage for:

- --version
- -V
- bare -v should fail
- hyphen-prefixed values should still parse correctly
- existing aliases and subcommand behavior should remain intact

## Validation

cargo fmt --all
cargo check --workspace --all-features
cargo test --workspace --all-features
cargo clippy --workspace --all-targets --all-features -- -D warnings