### PR TITLE
fix(schema): preserve root definitions for composite overlays

### DIFF
--- a/src/schema/dialect.rs
+++ b/src/schema/dialect.rs
@@ -1,0 +1,63 @@
+use serde_json::{Map, Value};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaDialect {
+    Draft7,
+    Draft202012,
+    Unknown,
+}
+
+impl SchemaDialect {
+    pub fn detect(schema: &Value) -> Self {
+        let Some(uri) = schema
+            .as_object()
+            .and_then(|obj| obj.get("$schema"))
+            .and_then(Value::as_str)
+        else {
+            return Self::Unknown;
+        };
+
+        if uri.contains("draft-07") {
+            Self::Draft7
+        } else if uri.contains("2020-12") {
+            Self::Draft202012
+        } else {
+            Self::Unknown
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RootDialectContext {
+    pub dialect: SchemaDialect,
+    pub schema_keyword: Option<Value>,
+    pub dollar_defs: Option<Value>,
+    pub definitions: Option<Value>,
+}
+
+impl RootDialectContext {
+    pub fn from_root(schema: &Value) -> Self {
+        let obj = schema.as_object();
+        Self {
+            dialect: SchemaDialect::detect(schema),
+            schema_keyword: obj.and_then(|map| map.get("$schema").cloned()),
+            dollar_defs: obj.and_then(|map| map.get("$defs").cloned()),
+            definitions: obj.and_then(|map| map.get("definitions").cloned()),
+        }
+    }
+
+    pub fn apply_to_overlay(&self, map: &mut Map<String, Value>) {
+        if let Some(schema_keyword) = &self.schema_keyword {
+            map.entry("$schema".to_string())
+                .or_insert_with(|| schema_keyword.clone());
+        }
+        if let Some(definitions) = &self.definitions {
+            map.entry("definitions".to_string())
+                .or_insert_with(|| definitions.clone());
+        }
+        if let Some(dollar_defs) = &self.dollar_defs {
+            map.entry("$defs".to_string())
+                .or_insert_with(|| dollar_defs.clone());
+        }
+    }
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,3 +1,4 @@
+pub mod dialect;
 pub mod loader;
 pub mod metadata;
 pub mod resolver;

--- a/src/schema/resolver.rs
+++ b/src/schema/resolver.rs
@@ -3,6 +3,8 @@ use percent_encoding::percent_decode_str;
 use schemars::schema::{Metadata, RootSchema, Schema, SchemaObject};
 use serde_json::Value;
 
+use super::dialect::RootDialectContext;
+
 #[derive(Debug)]
 pub struct SchemaResolver<'a> {
     raw: &'a Value,
@@ -32,9 +34,8 @@ impl<'a> SchemaResolver<'a> {
         }
     }
 
-    pub fn definitions_snapshot(&self) -> Option<Value> {
-        let obj = self.raw.as_object()?;
-        obj.get("$defs").or_else(|| obj.get("definitions")).cloned()
+    pub fn root_dialect_context(&self) -> RootDialectContext {
+        RootDialectContext::from_root(self.raw)
     }
 
     fn follow_reference(&self, reference: &str) -> Result<SchemaObject> {

--- a/src/tests/schema/dialect_tests.rs
+++ b/src/tests/schema/dialect_tests.rs
@@ -1,0 +1,52 @@
+use serde_json::json;
+
+use crate::schema::dialect::{RootDialectContext, SchemaDialect};
+
+#[test]
+fn detects_draft_07_from_schema_keyword() {
+    let schema = json!({
+        "$schema": "http://json-schema.org/draft-07/schema#"
+    });
+
+    assert_eq!(SchemaDialect::detect(&schema), SchemaDialect::Draft7);
+}
+
+#[test]
+fn detects_2020_12_from_schema_keyword() {
+    let schema = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
+    });
+
+    assert_eq!(SchemaDialect::detect(&schema), SchemaDialect::Draft202012);
+}
+
+#[test]
+fn root_dialect_context_applies_schema_and_definition_keywords_to_overlay() {
+    let root = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "bar": { "type": "string" }
+        },
+        "definitions": {
+            "legacy": { "type": "integer" }
+        }
+    });
+    let context = RootDialectContext::from_root(&root);
+    let mut overlay = serde_json::Map::new();
+    overlay.insert("type".to_string(), json!("object"));
+
+    context.apply_to_overlay(&mut overlay);
+
+    assert_eq!(
+        overlay.get("$schema"),
+        root.as_object().and_then(|obj| obj.get("$schema"))
+    );
+    assert_eq!(
+        overlay.get("$defs"),
+        root.as_object().and_then(|obj| obj.get("$defs"))
+    );
+    assert_eq!(
+        overlay.get("definitions"),
+        root.as_object().and_then(|obj| obj.get("definitions"))
+    );
+}

--- a/src/tests/schema/mod.rs
+++ b/src/tests/schema/mod.rs
@@ -1,5 +1,6 @@
 // #[cfg(feature = "precompile")]
 mod artifact_bundle_tests;
+mod dialect_tests;
 mod layout_tests;
 mod pipeline_artifact_tests;
 mod resolver_tests;

--- a/src/tests/tui/state/composite_tests.rs
+++ b/src/tests/tui/state/composite_tests.rs
@@ -2,10 +2,33 @@ use std::sync::Arc;
 
 use serde_json::json;
 
+fn defs_schema_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("schemas")
+        .join("test.defs.schema.json")
+}
+
+fn runtime_form_state(schema: &serde_json::Value) -> FormState {
+    let ast = build_ui_ast(schema).expect("ui ast");
+    let form_schema = form_schema_from_ui_ast(&ast);
+    FormState::from_schema(&form_schema)
+}
+
+fn defs_2020_12_schema_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("schemas")
+        .join("test.defs.2020-12.schema.json")
+}
+
 use crate::{
-    tui::model::{CompositeField, CompositeMode, CompositeVariant},
-    tui::state::CompositeState,
     tui::state::field::components::ComponentPalette,
+    tui::{
+        model::{CompositeField, CompositeMode, CompositeVariant, form_schema_from_ui_ast},
+        state::{CompositeState, FormState},
+    },
+    ui_ast::build_ui_ast,
 };
 
 #[test]
@@ -107,4 +130,48 @@ fn non_object_variant_round_trips_through_wrapper() {
         state.build_value(true).expect("build updated value"),
         Some(json!(["z"]))
     );
+}
+
+#[test]
+fn object_variant_overlay_keeps_root_dollar_defs_for_valid_2020_12_refs() {
+    let schema: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(defs_2020_12_schema_path()).expect("2020-12 defs schema readable"),
+    )
+    .expect("2020-12 defs schema json");
+
+    let mut state = runtime_form_state(&schema);
+    let field = state.field_mut_by_pointer("/blah").expect("blah field");
+    let session = field
+        .open_composite_editor(0)
+        .expect("valid 2020-12 $defs schema should build variant session");
+
+    assert_eq!(session.schema.get("$schema"), schema.get("$schema"));
+    assert_eq!(session.schema.get("$defs"), schema.get("$defs"));
+    assert!(
+        session.form_state.field_by_pointer("/Bar").is_some(),
+        "variant form should resolve $defs-backed referenced Bar field"
+    );
+    assert!(session.form_state.field_by_pointer("/Id").is_some());
+}
+
+#[test]
+fn draft_07_schema_with_dollar_defs_builds_overlay_session() {
+    let schema: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(defs_schema_path()).expect("defs schema readable"),
+    )
+    .expect("defs schema json");
+
+    let mut state = runtime_form_state(&schema);
+    let field = state.field_mut_by_pointer("/blah").expect("blah field");
+    let session = field
+        .open_composite_editor(0)
+        .expect("draft-07 + $defs schema should build variant session");
+
+    assert_eq!(session.schema.get("$schema"), schema.get("$schema"));
+    assert_eq!(session.schema.get("$defs"), schema.get("$defs"));
+    assert!(
+        session.form_state.field_by_pointer("/Bar").is_some(),
+        "variant form should resolve $defs-backed referenced Bar field"
+    );
+    assert!(session.form_state.field_by_pointer("/Id").is_some());
 }

--- a/src/ui_ast/builder.rs
+++ b/src/ui_ast/builder.rs
@@ -806,10 +806,8 @@ fn schema_to_value_with_defs(
     schema: &SchemaObject,
 ) -> Result<Value> {
     let mut value = schema_to_value(schema)?;
-    if let Some(defs) = resolver.definitions_snapshot()
-        && let Value::Object(ref mut map) = value
-    {
-        map.entry("definitions".to_string()).or_insert(defs);
+    if let Value::Object(ref mut map) = value {
+        resolver.root_dialect_context().apply_to_overlay(map);
     }
     Ok(value)
 }

--- a/tests/schemas/test.defs.2020-12.schema.json
+++ b/tests/schemas/test.defs.2020-12.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "My title",
+  "description": "My description",
+  "$defs": {
+    "bar": {
+      "type": "string"
+    },
+    "baz": {
+      "type": "integer"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "blah": {
+      "oneOf": [
+        {
+          "title": "Option 1",
+          "type": "object",
+          "properties": {
+            "Bar": {
+              "$ref": "#/$defs/bar"
+            },
+            "Id": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "title": "Option 2",
+          "type": "object",
+          "properties": {
+            "Baz": {
+              "$ref": "#/$defs/baz"
+            },
+            "Id": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/schemas/test.defs.2020-12.schema.json
+++ b/tests/schemas/test.defs.2020-12.schema.json
@@ -1,45 +1,55 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "My title",
-  "description": "My description",
-  "$defs": {
-    "bar": {
-      "type": "string"
-    },
-    "baz": {
-      "type": "integer"
-    }
-  },
-  "type": "object",
-  "properties": {
-    "blah": {
-      "oneOf": [
-        {
-          "title": "Option 1",
-          "type": "object",
-          "properties": {
-            "Bar": {
-              "$ref": "#/$defs/bar"
-            },
-            "Id": {
-              "type": "integer"
-            }
-          }
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "My title",
+    "description": "My description",
+    "$defs": {
+        "bar": {
+            "type": "string"
         },
-        {
-          "title": "Option 2",
-          "type": "object",
-          "properties": {
-            "Baz": {
-              "$ref": "#/$defs/baz"
-            },
-            "Id": {
-              "type": "integer"
-            }
-          }
+        "baz": {
+            "type": "integer"
         }
-      ]
-    }
-  },
-  "additionalProperties": false
+    },
+    "type": "object",
+    "properties": {
+        "blah": {
+            "oneOf": [
+                {
+                    "title": "Option 1",
+                    "type": "object",
+                    "properties": {
+                        "Bar": {
+                            "$ref": "#/$defs/bar"
+                        },
+                        "Id": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "Bar",
+                        "Id"
+                    ],
+                    "additionalProperties": false
+                },
+                {
+                    "title": "Option 2",
+                    "type": "object",
+                    "properties": {
+                        "Baz": {
+                            "$ref": "#/$defs/baz"
+                        },
+                        "Id": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "Baz",
+                        "Id"
+                    ],
+                    "additionalProperties": false
+                }
+            ]
+        }
+    },
+    "additionalProperties": false
 }

--- a/tests/schemas/test.defs.schema.json
+++ b/tests/schemas/test.defs.schema.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "My title",
+    "description": "My description",
+    "$defs": {
+        "bar": {
+            "type": "string"
+        },
+        "baz": {
+            "type": "integer"
+        }
+    },
+    "type": "object",
+    "properties": {
+        "blah": {
+            "oneOf": [
+                {
+                    "title": "Option 1",
+                    "properties": {
+                        "Bar": {
+                            "$ref": "#/$defs/bar"
+                        },
+                        "Id": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                {
+                    "title": "Option 2",
+                    "properties": {
+                        "Baz": {
+                            "$ref": "#/$defs/baz"
+                        },
+                        "Id": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "propertyNames": true,
+    "required": [],
+    "additionalProperties": false
+}

--- a/tests/schemas/test.defs.schema.json
+++ b/tests/schemas/test.defs.schema.json
@@ -23,7 +23,13 @@
                         "Id": {
                             "type": "integer"
                         }
-                    }
+                    },
+                    "type": "object",
+                    "required": [
+                        "Bar",
+                        "Id"
+                    ],
+                    "additionalProperties": false
                 },
                 {
                     "title": "Option 2",
@@ -34,7 +40,13 @@
                         "Id": {
                             "type": "integer"
                         }
-                    }
+                    },
+                    "type": "object",
+                    "required": [
+                        "Baz",
+                        "Id"
+                    ],
+                    "additionalProperties": false
                 }
             ]
         }


### PR DESCRIPTION
Closes #107

## Summary

This PR fixes composite overlay sessions losing access to root-level JSON Schema definitions.

When a `oneOf` / `anyOf` / composite overlay is opened, the generated overlay schema now keeps the root schema dialect context and
root definition keywords, so nested refs continue to resolve correctly.

### What changed

- add a root dialect context for schema processing
- preserve root `$schema` when building composite overlays
- preserve root `$defs` and `definitions` when building composite overlays
- add shared regression fixtures under `tests/schemas/`
- add regression tests for both draft-07-style refs and 2020-12 `$defs`

## Reproduction

### Before

Using the composite defs fixtures:

```bash
cargo run -p schemaui-cli --all-features -- tui -c ./tests/schemas/test.defs.schema.json
cargo run -p schemaui-cli --all-features -- tui -c ./tests/schemas/test.defs.2020-12.schema.json
```

Open the composite / oneOf overlay.

Before this fix:

- the overlay schema could lose the root definition context
- nested refs like #/$defs/... or #/definitions/... could stop resolving correctly inside the overlay
- the resulting overlay session could fail validation / render incorrectly

### After

After this fix:

- composite overlays keep the root schema dialect
- composite overlays keep root $defs / definitions
- nested refs resolve consistently inside overlay sessions
- the regression is covered by tests

## Fixture note

The test fixture from the issue comment has also been tightened so its oneOf branches are mutually exclusive.

That means the test schema now avoids ambiguous matches by adding the missing branch constraints, instead of leaving the fixture
in a state where one payload is valid under multiple branches.

## Notes

- draft-07 remains the default/stable UI mapping target
- validator behavior still follows $schema
- draft-07 + $defs is intentionally tolerated instead of rejected
- this change is not a one-off hack for a single schema; it preserves root schema context in the overlay path

## Tests

Added / updated:

- tests/schemas/test.defs.schema.json
- tests/schemas/test.defs.2020-12.schema.json
- src/tests/schema/dialect_tests.rs
- src/tests/tui/state/composite_tests.rs

## Validation

cargo fmt --all
cargo check --workspace --all-features
cargo test --workspace --all-features
cargo clippy --workspace --all-targets --all-features -- -D warnings