### PR TITLE
Fix CLI config error reporting and improve TUI list summaries

### DIFF
--- a/docs/en/cli_usage.md
+++ b/docs/en/cli_usage.md
@@ -289,9 +289,10 @@ least one of `json`, `yaml`, or `toml` must remain enabled.
 
 ## 10. Operational Tips
 
-- Pass one stream as literal text (a non-existent path is treated inline) when
-  both schema and config would otherwise require stdin; the executable only
-  reads stdin once.
+- Pass one stream as literal JSON/YAML/TOML text when both schema and config
+  would otherwise require stdin; the executable only reads stdin once. File-like
+  specs that miss on disk now report a file-loading error instead of silently
+  falling back to inline parsing.
 - Prefer explicit extensions for outputs—format inference uses the first file’s
   suffix, and mismatches across files are rejected.
 - Combine `-o -` with file outputs to tee the result into CI logs while still

--- a/docs/zh/cli_usage.zh.md
+++ b/docs/zh/cli_usage.zh.md
@@ -221,8 +221,9 @@ if let Some(options) = output_settings.as_ref() {
 
 ## 10. 操作提示
 
-- 如果 schema 和 config 都想走
-  stdin，就把其中一个改为内联文本；可执行文件只会消费一次 stdin。
+- 如果 schema 和 config 都想走 stdin，就把其中一个改为内联
+  JSON/YAML/TOML 文本；可执行文件只会消费一次 stdin。像 `test.json`
+  这类“看起来就是文件路径”的 spec 若磁盘上不存在，现在会直接报文件加载错误，不再悄悄回退成内联解析。
 - 输出最好总是带扩展名；格式推断使用第一个文件的后缀，跨文件冲突会被直接拒绝。
 - 可以把 `-o -` 和文件输出同时使用，这样既能进 CI 日志，也能真正落盘。
 

--- a/docs/zh/cli_usage.zh.md
+++ b/docs/zh/cli_usage.zh.md
@@ -221,9 +221,9 @@ if let Some(options) = output_settings.as_ref() {
 
 ## 10. 操作提示
 
-- 如果 schema 和 config 都想走 stdin，就把其中一个改为内联
-  JSON/YAML/TOML 文本；可执行文件只会消费一次 stdin。像 `test.json`
-  这类“看起来就是文件路径”的 spec 若磁盘上不存在，现在会直接报文件加载错误，不再悄悄回退成内联解析。
+- 如果 schema 和 config 都想走 stdin，就把其中一个改为内联 JSON/YAML/TOML
+  文本；可执行文件只会消费一次 stdin。像 `test.json` 这类“看起来就是文件路径”的
+  spec 若磁盘上不存在，现在会直接报文件加载错误，不再悄悄回退成内联解析。
 - 输出最好总是带扩展名；格式推断使用第一个文件的后缀，跨文件冲突会被直接拒绝。
 - 可以把 `-o -` 和文件输出同时使用，这样既能进 CI 日志，也能真正落盘。
 

--- a/schemaui-cli/src/session/schema_source.rs
+++ b/schemaui-cli/src/session/schema_source.rs
@@ -95,15 +95,20 @@ pub(crate) fn load_document(
             })
         }
         Err(err) if err.kind() == io::ErrorKind::NotFound => {
-            let inline_label = format!("inline {label}");
-            let value = parse_contents(spec, format, &inline_label)?;
-            Ok(LoadedDocument {
-                value,
-                #[cfg(any(feature = "yaml", feature = "toml"))]
-                raw: spec.to_string(),
-                format,
-                origin: DocumentOrigin::Inline,
-            })
+            if should_treat_missing_path_as_inline_payload(spec) {
+                let inline_label = format!("inline {label}");
+                let value = parse_contents(spec, format, &inline_label)?;
+                Ok(LoadedDocument {
+                    value,
+                    #[cfg(any(feature = "yaml", feature = "toml"))]
+                    raw: spec.to_string(),
+                    format,
+                    origin: DocumentOrigin::Inline,
+                })
+            } else {
+                Err(Report::new(err)
+                    .wrap_err(format!("failed to load {label} from {}", path.display())))
+            }
         }
         Err(err) => {
             Err(Report::new(err)
@@ -422,6 +427,34 @@ fn parse_special_url(spec: &str) -> Option<Url> {
         "http" | "https" | "file" => Some(url),
         _ => None,
     }
+}
+
+fn should_treat_missing_path_as_inline_payload(spec: &str) -> bool {
+    let trimmed = spec.trim();
+    !trimmed.is_empty()
+        && (looks_like_structured_inline_payload(trimmed) || !looks_like_file_path(trimmed))
+}
+
+fn looks_like_structured_inline_payload(spec: &str) -> bool {
+    spec.contains('\n')
+        || spec.starts_with('{')
+        || spec.starts_with('[')
+        || spec.starts_with('"')
+        || spec.starts_with('\'')
+        || spec.starts_with("---")
+        || spec.starts_with('#')
+        || spec.contains(": ")
+        || spec.contains(":\n")
+        || spec.contains(" = ")
+        || spec.contains("=\n")
+}
+
+fn looks_like_file_path(spec: &str) -> bool {
+    let path = Path::new(spec);
+    spec.starts_with('.')
+        || spec.starts_with('~')
+        || spec.contains(std::path::MAIN_SEPARATOR)
+        || path.extension().is_some()
 }
 
 #[cfg(feature = "remote-schema")]

--- a/schemaui-cli/tests/schema_auto_detection.rs
+++ b/schemaui-cli/tests/schema_auto_detection.rs
@@ -166,6 +166,60 @@ fn prepare_session_preserves_cli_description_override() {
     let _ = fs::remove_dir_all(temp);
 }
 
+#[test]
+fn prepare_session_reports_missing_file_like_config_instead_of_inlining_it() {
+    let temp = unique_temp_dir("missing_config");
+    let missing_path = temp.join("missing.json");
+
+    let err = prepare_session(&base_args(
+        None,
+        Some(missing_path.to_string_lossy().into_owned()),
+    ))
+    .expect_err("missing file-like config should fail");
+    let message = err.to_string();
+
+    assert!(
+        message.contains("failed to load config from"),
+        "missing file should be surfaced as a file-loading error: {message}"
+    );
+    assert!(
+        message.contains("missing.json"),
+        "error should include the missing file path: {message}"
+    );
+    assert!(
+        !message.contains("root schema must describe an object"),
+        "missing file should not fall back into bogus schema inference: {message}"
+    );
+
+    let _ = fs::remove_dir_all(temp);
+}
+
+#[test]
+fn prepare_session_accepts_inline_config_payloads_that_look_like_documents() {
+    let temp = unique_temp_dir("inline_config_payload");
+    let schema_path = temp.join("schema.json");
+    write_json(
+        &schema_path,
+        &json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            }
+        }),
+    );
+
+    let session = prepare_session(&base_args(
+        Some(schema_path.to_string_lossy().into_owned()),
+        Some("name: alice".to_string()),
+    ))
+    .expect("inline yaml config should still be accepted");
+
+    assert_eq!(session.defaults, Some(json!({ "name": "alice" })));
+
+    let _ = fs::remove_dir_all(temp);
+}
+
 #[cfg(feature = "yaml")]
 #[test]
 fn prepare_session_prefers_explicit_local_schema_over_yaml_header_declaration() {

--- a/src/tests/tui/components/component_collection_tests.rs
+++ b/src/tests/tui/components/component_collection_tests.rs
@@ -1,4 +1,10 @@
-use crate::tui::state::field::components::helpers::format_collection_value;
+use std::collections::HashMap;
+
+use crate::tui::{
+    model::{CompositeField, CompositeMode, CompositeVariant, FieldKind, FieldSchema},
+    state::{FieldState, field::components::helpers::format_collection_value},
+};
+use serde_json::json;
 
 #[test]
 fn formats_collection_status_with_selection() {
@@ -10,4 +16,56 @@ fn formats_collection_status_with_selection() {
 fn formats_collection_status_when_empty() {
     let text = format_collection_value("List", 0, None, "(Ctrl+N add)");
     assert_eq!(text, "List: empty (Ctrl+N add)");
+}
+
+#[test]
+fn composite_list_display_value_uses_available_width_for_selected_entry() {
+    let variants = vec![CompositeVariant {
+        id: "bar".to_string(),
+        title: "Bar Item".to_string(),
+        description: None,
+        schema: json!({
+            "type": "object",
+            "properties": {
+                "Bar": {"type": "string"},
+                "Id": {"type": "integer"}
+            }
+        }),
+        is_object: true,
+    }];
+
+    let template = CompositeField {
+        mode: CompositeMode::AnyOf,
+        variants,
+    };
+
+    let mut field = FieldState::from_schema(FieldSchema {
+        name: "blahList".to_string(),
+        path: vec!["blahList".to_string()],
+        pointer: "/blahList".to_string(),
+        title: "Blah List".to_string(),
+        description: None,
+        kind: FieldKind::Array(Box::new(FieldKind::Composite(Box::new(template)))),
+        required: false,
+        default: None,
+        metadata: HashMap::new(),
+    });
+    field.seed_value(&json!([{
+        "Bar": "客服热线 400-820-8820 转人工服务",
+        "Id": 0
+    }]));
+
+    let text = field.display_value_with_limit(64);
+    assert!(
+        text.contains("Variants: #1 Bar Item"),
+        "display text: {text}"
+    );
+    assert!(
+        !text.contains("Bar:"),
+        "display text should stay compact: {text}"
+    );
+    assert!(
+        !text.contains("Id: 0"),
+        "display text should stay compact: {text}"
+    );
 }

--- a/src/tests/tui/components/fields_tests.rs
+++ b/src/tests/tui/components/fields_tests.rs
@@ -1,4 +1,4 @@
-use crate::tui::view::components::fields::meta_lines;
+use crate::tui::view::components::fields::{error_lines, meta_lines};
 use crate::{
     tui::model::{FieldKind, FieldSchema},
     tui::state::FieldState,
@@ -41,4 +41,27 @@ fn meta_line_unselected_uses_gray() {
         .expect("type span");
     assert_eq!(span.style.fg, Some(Color::DarkGray));
     assert!(!span.style.add_modifier.contains(Modifier::BOLD));
+}
+
+#[test]
+fn error_lines_wrap_and_cap_at_three_lines() {
+    let mut field = make_field();
+    field.set_error(
+        "this validation error is intentionally long so the renderer must wrap it across multiple lines without letting the panel grow forever".to_string(),
+    );
+
+    let lines = error_lines(&field, 28).expect("error lines");
+    assert_eq!(lines.len(), 4, "label + at most 3 wrapped lines");
+
+    let last = lines
+        .last()
+        .expect("last wrapped line")
+        .spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect::<String>();
+    assert!(
+        last.contains('…'),
+        "truncated final line should end with ellipsis: {last}"
+    );
 }

--- a/src/tests/tui/state/composite_list_tests.rs
+++ b/src/tests/tui/state/composite_list_tests.rs
@@ -127,3 +127,49 @@ fn composite_list_adds_entries_with_selected_variants() {
         entries[1]
     );
 }
+
+#[test]
+fn composite_list_summary_includes_object_preview() {
+    let variants = vec![CompositeVariant {
+        id: "bar".to_string(),
+        title: "Bar Item".to_string(),
+        description: None,
+        schema: json!({
+            "type": "object",
+            "properties": {
+                "Bar": {"type": "string"},
+                "Id": {"type": "integer"}
+            }
+        }),
+        is_object: true,
+    }];
+    let template = CompositeField {
+        mode: CompositeMode::AnyOf,
+        variants,
+    };
+
+    let mut field = FieldState::from_schema(FieldSchema {
+        name: "blahList".to_string(),
+        path: vec!["blahList".to_string()],
+        pointer: "/blahList".to_string(),
+        title: "Blah List".to_string(),
+        description: None,
+        kind: FieldKind::Array(Box::new(FieldKind::Composite(Box::new(template)))),
+        required: false,
+        default: None,
+        metadata: HashMap::new(),
+    });
+    field.seed_value(&json!([{
+        "Bar": "on tui",
+        "Id": 0
+    }]));
+
+    let (entries, selected) = field.composite_list_panel().expect("panel state");
+    assert_eq!(selected, 0);
+    assert_eq!(entries.len(), 1);
+    assert!(
+        entries[0].contains("Bar Item { Bar: on tui, Id: 0 }"),
+        "entry summary should include object preview: {:?}",
+        entries[0]
+    );
+}

--- a/src/tests/tui/state/composite_list_tests.rs
+++ b/src/tests/tui/state/composite_list_tests.rs
@@ -173,3 +173,61 @@ fn composite_list_summary_includes_object_preview() {
         entries[0]
     );
 }
+
+#[test]
+fn composite_list_summary_with_limit_keeps_bar_and_id_visible() {
+    let variants = vec![CompositeVariant {
+        id: "bar".to_string(),
+        title: "Bar Item".to_string(),
+        description: None,
+        schema: json!({
+            "type": "object",
+            "properties": {
+                "Bar": {"type": "string"},
+                "Id": {"type": "integer"}
+            }
+        }),
+        is_object: true,
+    }];
+    let template = CompositeField {
+        mode: CompositeMode::AnyOf,
+        variants,
+    };
+
+    let mut field = FieldState::from_schema(FieldSchema {
+        name: "blahList".to_string(),
+        path: vec!["blahList".to_string()],
+        pointer: "/blahList".to_string(),
+        title: "Blah List".to_string(),
+        description: None,
+        kind: FieldKind::Array(Box::new(FieldKind::Composite(Box::new(template)))),
+        required: false,
+        default: None,
+        metadata: HashMap::new(),
+    });
+    field.seed_value(&json!([{
+        "Bar": "客服热线 400-820-8820 转人工服务",
+        "Id": 0
+    }]));
+
+    let (entries, selected) = field
+        .composite_list_panel_with_limit(44)
+        .expect("panel state");
+    assert_eq!(selected, 0);
+    assert_eq!(entries.len(), 1);
+    assert!(
+        entries[0].contains("Bar:"),
+        "entry summary: {:?}",
+        entries[0]
+    );
+    assert!(
+        entries[0].contains("Id: 0"),
+        "entry summary: {:?}",
+        entries[0]
+    );
+    let compact = field
+        .composite_list_selected_label_with_limit(44)
+        .expect("compact selected label");
+    assert!(!compact.contains("Bar:"), "compact label: {compact}");
+    assert!(!compact.contains("Id: 0"), "compact label: {compact}");
+}

--- a/src/tests/tui/state/key_value_tests.rs
+++ b/src/tests/tui/state/key_value_tests.rs
@@ -1,4 +1,4 @@
-use crate::tui::state::value_summary::summarize_value;
+use crate::tui::state::value_summary::{summarize_value, summarize_value_with_limit};
 use serde_json::{Value, json};
 
 #[test]
@@ -25,4 +25,15 @@ fn summarize_value_renders_object_preview() {
     });
     let summary = summarize_value(&value);
     assert_eq!(summary, "{ Bar: on tui, Id: 0 }");
+}
+
+#[test]
+fn summarize_value_with_limit_preserves_multiple_object_fields_when_space_allows() {
+    let value = json!({
+        "Bar": "客服热线 400-820-8820 转人工服务",
+        "Id": 0
+    });
+    let summary = summarize_value_with_limit(&value, 42);
+    assert!(summary.contains("Bar:"), "summary: {summary}");
+    assert!(summary.contains("Id: 0"), "summary: {summary}");
 }

--- a/src/tests/tui/state/key_value_tests.rs
+++ b/src/tests/tui/state/key_value_tests.rs
@@ -1,5 +1,5 @@
-use crate::tui::state::key_value::summarize_value;
-use serde_json::Value;
+use crate::tui::state::value_summary::summarize_value;
+use serde_json::{Value, json};
 
 #[test]
 fn summarize_value_handles_unicode_without_panic() {
@@ -15,4 +15,14 @@ fn summarize_value_truncates_long_strings_on_char_boundaries() {
     let value = Value::String(long.to_string());
     let summary = summarize_value(&value);
     assert_eq!(summary, "\"abcdefghijklmnoabcdefghi…\"");
+}
+
+#[test]
+fn summarize_value_renders_object_preview() {
+    let value = json!({
+        "Bar": "on tui",
+        "Id": 0
+    });
+    let summary = summarize_value(&value);
+    assert_eq!(summary, "{ Bar: on tui, Id: 0 }");
 }

--- a/src/tui/state/array.rs
+++ b/src/tui/state/array.rs
@@ -6,7 +6,7 @@ use crate::tui::model::{FieldKind, FieldSchema};
 
 use super::{
     error::FieldCoercionError, field::FieldState, field::components::ComponentPalette,
-    form_state::FormState, section::SectionState,
+    form_state::FormState, section::SectionState, value_summary::summarize_value,
 };
 
 #[derive(Debug, Clone)]
@@ -322,22 +322,5 @@ fn default_value(kind: &FieldKind) -> Value {
             .unwrap_or_else(|| Value::String(String::new())),
         FieldKind::Nullable(_) => Value::Null,
         _ => Value::String(String::new()),
-    }
-}
-
-fn summarize_value(value: &Value) -> String {
-    match value {
-        Value::Null => "null".to_string(),
-        Value::Bool(flag) => flag.to_string(),
-        Value::Number(num) => num.to_string(),
-        Value::String(text) => {
-            if text.len() > 24 {
-                format!("\"{}…\"", &text[..24])
-            } else {
-                format!("\"{text}\"")
-            }
-        }
-        Value::Array(items) => format!("array({})", items.len()),
-        Value::Object(map) => format!("object({})", map.len()),
     }
 }

--- a/src/tui/state/array.rs
+++ b/src/tui/state/array.rs
@@ -1,12 +1,17 @@
 use std::sync::Arc;
 
 use serde_json::{Number, Value, json};
+use unicode_width::UnicodeWidthStr;
 
 use crate::tui::model::{FieldKind, FieldSchema};
 
 use super::{
-    error::FieldCoercionError, field::FieldState, field::components::ComponentPalette,
-    form_state::FormState, section::SectionState, value_summary::summarize_value,
+    error::FieldCoercionError,
+    field::FieldState,
+    field::components::ComponentPalette,
+    form_state::FormState,
+    section::SectionState,
+    value_summary::{summarize_value, summarize_value_with_limit},
 };
 
 #[derive(Debug, Clone)]
@@ -151,6 +156,21 @@ impl ScalarArrayState {
         Some(format!("#{} {}", idx + 1, summarize_value(value)))
     }
 
+    pub fn selected_label_with_limit(&self, max_visible: usize) -> Option<String> {
+        let idx = self.selected_index()?;
+        let value = self.entries.get(idx)?;
+        let prefix = format!("#{} ", idx + 1);
+        Some(format!(
+            "{prefix}{}",
+            summarize_value_with_limit(
+                value,
+                max_visible
+                    .saturating_sub(UnicodeWidthStr::width(prefix.as_str()))
+                    .max(1),
+            )
+        ))
+    }
+
     pub fn summaries(&self) -> Vec<String> {
         self.entries
             .iter()
@@ -159,9 +179,33 @@ impl ScalarArrayState {
             .collect()
     }
 
+    pub fn summaries_with_limit(&self, max_visible: usize) -> Vec<String> {
+        self.entries
+            .iter()
+            .enumerate()
+            .map(|(idx, value)| {
+                let prefix = format!("#{} ", idx + 1);
+                format!(
+                    "{prefix}{}",
+                    summarize_value_with_limit(
+                        value,
+                        max_visible
+                            .saturating_sub(UnicodeWidthStr::width(prefix.as_str()))
+                            .max(1),
+                    )
+                )
+            })
+            .collect()
+    }
+
     pub fn panel(&self) -> Option<(Vec<String>, usize)> {
         let idx = self.selected_index()?;
         Some((self.summaries(), idx))
+    }
+
+    pub fn panel_with_limit(&self, max_visible: usize) -> Option<(Vec<String>, usize)> {
+        let idx = self.selected_index()?;
+        Some((self.summaries_with_limit(max_visible), idx))
     }
 
     pub fn seed_entries_from_array(&mut self, items: &[Value]) {

--- a/src/tui/state/composite.rs
+++ b/src/tui/state/composite.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::{
     LayoutNavModel, error::FieldCoercionError, field::components::ComponentPalette,
-    form_state::FormState,
+    form_state::FormState, value_summary::summarize_inline_value,
 };
 
 mod composite_list;
@@ -115,6 +115,14 @@ impl CompositeState {
         }
     }
 
+    pub fn summary_with_preview(&self) -> String {
+        let summary = self.summary();
+        match self.active_preview() {
+            Some(preview) if !preview.is_empty() => format!("{summary} {preview}"),
+            _ => summary,
+        }
+    }
+
     pub fn pointer(&self) -> &str {
         &self.pointer
     }
@@ -175,6 +183,28 @@ impl CompositeState {
             }
         }
         summaries
+    }
+
+    fn active_preview(&self) -> Option<String> {
+        let mut previews = Vec::new();
+        for variant in self.variants.iter().filter(|variant| variant.active) {
+            let Ok(form) = variant.borrow_form(self.pointer()) else {
+                continue;
+            };
+            let Ok(value) = form.try_build_value() else {
+                continue;
+            };
+            let Ok(actual) = variant.unwrap_overlay_value(value, self.pointer()) else {
+                continue;
+            };
+            previews.push(summarize_inline_value(&actual));
+        }
+
+        if previews.is_empty() {
+            None
+        } else {
+            Some(previews.join(" + "))
+        }
     }
 
     pub fn option_titles(&self) -> Vec<String> {

--- a/src/tui/state/composite.rs
+++ b/src/tui/state/composite.rs
@@ -11,8 +11,11 @@ use crate::{
 };
 
 use super::{
-    LayoutNavModel, error::FieldCoercionError, field::components::ComponentPalette,
-    form_state::FormState, value_summary::summarize_inline_value,
+    LayoutNavModel,
+    error::FieldCoercionError,
+    field::components::ComponentPalette,
+    form_state::FormState,
+    value_summary::{summarize_inline_value, summarize_inline_value_with_limit},
 };
 
 mod composite_list;
@@ -123,6 +126,10 @@ impl CompositeState {
         }
     }
 
+    pub fn summary_with_preview_limit(&self, max_visible: usize) -> String {
+        truncate_summary_with_preview(self, max_visible)
+    }
+
     pub fn pointer(&self) -> &str {
         &self.pointer
     }
@@ -198,6 +205,32 @@ impl CompositeState {
                 continue;
             };
             previews.push(summarize_inline_value(&actual));
+        }
+
+        if previews.is_empty() {
+            None
+        } else {
+            Some(previews.join(" + "))
+        }
+    }
+
+    fn active_preview_with_limit(&self, max_visible: usize) -> Option<String> {
+        if max_visible == 0 {
+            return None;
+        }
+
+        let mut previews = Vec::new();
+        for variant in self.variants.iter().filter(|variant| variant.active) {
+            let Ok(form) = variant.borrow_form(self.pointer()) else {
+                continue;
+            };
+            let Ok(value) = form.try_build_value() else {
+                continue;
+            };
+            let Ok(actual) = variant.unwrap_overlay_value(value, self.pointer()) else {
+                continue;
+            };
+            previews.push(summarize_inline_value_with_limit(&actual, max_visible));
         }
 
         if previews.is_empty() {
@@ -403,6 +436,37 @@ impl CompositeState {
                 }
             }
         }
+    }
+}
+
+fn truncate_summary_with_preview(state: &CompositeState, max_visible: usize) -> String {
+    use super::value_summary::truncate_visible_text;
+    use unicode_width::UnicodeWidthStr;
+
+    if max_visible == 0 {
+        return String::new();
+    }
+
+    let summary = state.summary();
+    let summary_width = UnicodeWidthStr::width(summary.as_str());
+    let separator = " ";
+    let separator_width = 1usize;
+
+    if summary_width >= max_visible {
+        return truncate_visible_text(&summary, max_visible);
+    }
+
+    let preview_budget = max_visible.saturating_sub(summary_width + separator_width);
+    if preview_budget == 0 {
+        return truncate_visible_text(&summary, max_visible);
+    }
+
+    match state
+        .active_preview_with_limit(preview_budget)
+        .filter(|text| !text.is_empty())
+    {
+        Some(preview) => format!("{summary}{separator}{preview}"),
+        None => summary,
     }
 }
 

--- a/src/tui/state/composite/composite_list.rs
+++ b/src/tui/state/composite/composite_list.rs
@@ -145,14 +145,18 @@ impl CompositeListState {
     pub fn selected_label(&self) -> Option<String> {
         let idx = self.selected_index()?;
         let entry = self.entries.get(idx)?;
-        Some(format!("#{} {}", idx + 1, entry.state.summary()))
+        Some(format!(
+            "#{} {}",
+            idx + 1,
+            entry.state.summary_with_preview()
+        ))
     }
 
     pub fn summaries(&self) -> Vec<String> {
         self.entries
             .iter()
             .enumerate()
-            .map(|(idx, entry)| format!("#{} {}", idx + 1, entry.state.summary()))
+            .map(|(idx, entry)| format!("#{} {}", idx + 1, entry.state.summary_with_preview()))
             .collect()
     }
 
@@ -193,7 +197,7 @@ impl CompositeListState {
             .take_editor_session(&entry.pointer, variant_index)?;
         Ok(CompositeListEditorContext {
             entry_index: idx,
-            entry_label: format!("#{} {}", idx + 1, entry.state.summary()),
+            entry_label: format!("#{} {}", idx + 1, entry.state.summary_with_preview()),
             session,
         })
     }

--- a/src/tui/state/composite/composite_list.rs
+++ b/src/tui/state/composite/composite_list.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
 use serde_json::Value;
+use unicode_width::UnicodeWidthStr;
 
 use crate::tui::model::CompositeField;
-use crate::tui::state::error::FieldCoercionError;
 use crate::tui::state::field::components::{
     ComponentPalette, CompositePopupData, CompositeSelectorView,
 };
+use crate::tui::state::{error::FieldCoercionError, value_summary::truncate_visible_text};
 
 use super::{CompositeEditorSession, CompositeState};
 
@@ -152,11 +153,39 @@ impl CompositeListState {
         ))
     }
 
+    pub fn selected_compact_label(&self) -> Option<String> {
+        let idx = self.selected_index()?;
+        let entry = self.entries.get(idx)?;
+        Some(format!("#{} {}", idx + 1, entry.state.summary()))
+    }
+
+    pub fn selected_compact_label_with_limit(&self, max_visible: usize) -> Option<String> {
+        let label = self.selected_compact_label()?;
+        Some(truncate_visible_text(&label, max_visible))
+    }
+
     pub fn summaries(&self) -> Vec<String> {
         self.entries
             .iter()
             .enumerate()
             .map(|(idx, entry)| format!("#{} {}", idx + 1, entry.state.summary_with_preview()))
+            .collect()
+    }
+
+    pub fn summaries_with_limit(&self, max_visible: usize) -> Vec<String> {
+        self.entries
+            .iter()
+            .enumerate()
+            .map(|(idx, entry)| {
+                let prefix = format!("#{} ", idx + 1);
+                let prefix_width = UnicodeWidthStr::width(prefix.as_str());
+                format!(
+                    "{prefix}{}",
+                    entry.state.summary_with_preview_limit(
+                        max_visible.saturating_sub(prefix_width).max(1)
+                    )
+                )
+            })
             .collect()
     }
 

--- a/src/tui/state/field/components/base.rs
+++ b/src/tui/state/field/components/base.rs
@@ -26,6 +26,9 @@ pub enum ComponentKind {
 pub(crate) trait FieldComponent: FieldComponentClone + std::fmt::Debug {
     fn kind(&self) -> ComponentKind;
     fn display_value(&self, schema: &FieldSchema) -> String;
+    fn display_value_with_limit(&self, schema: &FieldSchema, _max_visible: usize) -> String {
+        self.display_value(schema)
+    }
     fn handle_key(&mut self, schema: &FieldSchema, key: &KeyEvent) -> bool {
         let _ = (schema, key);
         false
@@ -102,8 +105,16 @@ pub(crate) trait FieldComponent: FieldComponentClone + std::fmt::Debug {
         None
     }
 
+    fn collection_panel_with_limit(&self, _max_visible: usize) -> Option<(Vec<String>, usize)> {
+        self.collection_panel()
+    }
+
     fn collection_selected_label(&self) -> Option<String> {
         None
+    }
+
+    fn collection_selected_label_with_limit(&self, _max_visible: usize) -> Option<String> {
+        self.collection_selected_label()
     }
 
     fn collection_selected_index(&self) -> Option<usize> {

--- a/src/tui/state/field/components/composite.rs
+++ b/src/tui/state/field/components/composite.rs
@@ -38,6 +38,10 @@ impl FieldComponent for CompositeComponent {
         self.view.display_label(&self.state)
     }
 
+    fn display_value_with_limit(&self, _schema: &FieldSchema, max_visible: usize) -> String {
+        self.view.display_label_with_limit(&self.state, max_visible)
+    }
+
     fn handle_key(&mut self, _schema: &FieldSchema, key: &crossterm::event::KeyEvent) -> bool {
         match key.code {
             KeyCode::Left => self.state.rotate_single(-1),
@@ -110,6 +114,19 @@ impl CompositeViewAdapter {
         } else {
             label.push_str(self.palette.composite.single_variant_hint.as_ref());
         }
+        label
+    }
+
+    fn display_label_with_limit(&self, state: &CompositeState, max_visible: usize) -> String {
+        let hint = if state.is_multi() {
+            self.palette.composite.multi_variant_hint.as_ref()
+        } else {
+            self.palette.composite.single_variant_hint.as_ref()
+        };
+        let hint_width = unicode_width::UnicodeWidthStr::width(hint);
+        let summary_budget = max_visible.saturating_sub(hint_width).max(1);
+        let mut label = state.summary_with_preview_limit(summary_budget);
+        label.push_str(hint);
         label
     }
 

--- a/src/tui/state/field/components/composite.rs
+++ b/src/tui/state/field/components/composite.rs
@@ -104,7 +104,7 @@ struct CompositeViewAdapter {
 
 impl CompositeViewAdapter {
     fn display_label(&self, state: &CompositeState) -> String {
-        let mut label = state.summary();
+        let mut label = state.summary_with_preview();
         if state.is_multi() {
             label.push_str(self.palette.composite.multi_variant_hint.as_ref());
         } else {

--- a/src/tui/state/field/components/composite_list.rs
+++ b/src/tui/state/field/components/composite_list.rs
@@ -43,7 +43,16 @@ impl FieldComponent for CompositeListComponent {
         format_collection_value(
             "List",
             self.state.len(),
-            self.state.selected_label(),
+            self.state.selected_compact_label(),
+            &list_hint_for(ComponentKind::CompositeList, &self.palette),
+        )
+    }
+
+    fn display_value_with_limit(&self, _schema: &FieldSchema, max_visible: usize) -> String {
+        format_collection_value(
+            "List",
+            self.state.len(),
+            self.state.selected_compact_label_with_limit(max_visible),
             &list_hint_for(ComponentKind::CompositeList, &self.palette),
         )
     }
@@ -64,8 +73,18 @@ impl FieldComponent for CompositeListComponent {
             .map(|idx| (self.state.summaries(), idx))
     }
 
+    fn collection_panel_with_limit(&self, max_visible: usize) -> Option<(Vec<String>, usize)> {
+        self.state
+            .selected_index()
+            .map(|idx| (self.state.summaries_with_limit(max_visible), idx))
+    }
+
     fn collection_selected_label(&self) -> Option<String> {
-        self.state.selected_label()
+        self.state.selected_compact_label()
+    }
+
+    fn collection_selected_label_with_limit(&self, max_visible: usize) -> Option<String> {
+        self.state.selected_compact_label_with_limit(max_visible)
     }
 
     fn collection_selected_index(&self) -> Option<usize> {

--- a/src/tui/state/field/components/key_value.rs
+++ b/src/tui/state/field/components/key_value.rs
@@ -43,6 +43,15 @@ impl FieldComponent for KeyValueComponent {
         )
     }
 
+    fn display_value_with_limit(&self, _schema: &FieldSchema, max_visible: usize) -> String {
+        format_collection_value(
+            "Map",
+            self.state.len(),
+            self.state.selected_label_with_limit(max_visible),
+            &list_hint_for(ComponentKind::KeyValue, &self.palette),
+        )
+    }
+
     fn seed_value(&mut self, _schema: &FieldSchema, value: &Value) {
         if let Value::Object(map) = value {
             self.state.seed_entries_from_object(map);
@@ -57,8 +66,16 @@ impl FieldComponent for KeyValueComponent {
         self.state.panel()
     }
 
+    fn collection_panel_with_limit(&self, max_visible: usize) -> Option<(Vec<String>, usize)> {
+        self.state.panel_with_limit(max_visible)
+    }
+
     fn collection_selected_label(&self) -> Option<String> {
         self.state.selected_label()
+    }
+
+    fn collection_selected_label_with_limit(&self, max_visible: usize) -> Option<String> {
+        self.state.selected_label_with_limit(max_visible)
     }
 
     fn collection_selected_index(&self) -> Option<usize> {

--- a/src/tui/state/field/components/scalar_array.rs
+++ b/src/tui/state/field/components/scalar_array.rs
@@ -45,6 +45,15 @@ impl FieldComponent for ScalarArrayComponent {
         )
     }
 
+    fn display_value_with_limit(&self, _schema: &FieldSchema, max_visible: usize) -> String {
+        format_collection_value(
+            "Array",
+            self.state.len(),
+            self.state.selected_label_with_limit(max_visible),
+            &list_hint_for(ComponentKind::ScalarArray, &self.palette),
+        )
+    }
+
     fn seed_value(&mut self, _schema: &FieldSchema, value: &Value) {
         if let Value::Array(items) = value {
             self.state.seed_entries_from_array(items);
@@ -59,8 +68,16 @@ impl FieldComponent for ScalarArrayComponent {
         self.state.panel()
     }
 
+    fn collection_panel_with_limit(&self, max_visible: usize) -> Option<(Vec<String>, usize)> {
+        self.state.panel_with_limit(max_visible)
+    }
+
     fn collection_selected_label(&self) -> Option<String> {
         self.state.selected_label()
+    }
+
+    fn collection_selected_label_with_limit(&self, max_visible: usize) -> Option<String> {
+        self.state.selected_label_with_limit(max_visible)
     }
 
     fn collection_selected_index(&self) -> Option<usize> {

--- a/src/tui/state/field/state/lists.rs
+++ b/src/tui/state/field/state/lists.rs
@@ -80,12 +80,29 @@ impl FieldState {
         self.component.collection_selected_label()
     }
 
+    pub fn composite_list_selected_label_with_limit(&self, max_visible: usize) -> Option<String> {
+        self.component
+            .collection_selected_label_with_limit(max_visible)
+    }
+
     pub fn collection_selected_label(&self) -> Option<String> {
         self.component.collection_selected_label()
     }
 
+    pub fn collection_selected_label_with_limit(&self, max_visible: usize) -> Option<String> {
+        self.component
+            .collection_selected_label_with_limit(max_visible)
+    }
+
     pub fn composite_list_panel(&self) -> Option<(Vec<String>, usize)> {
         self.component.collection_panel()
+    }
+
+    pub fn composite_list_panel_with_limit(
+        &self,
+        max_visible: usize,
+    ) -> Option<(Vec<String>, usize)> {
+        self.component.collection_panel_with_limit(max_visible)
     }
 
     pub fn composite_list_selected_index(&self) -> Option<usize> {

--- a/src/tui/state/field/state/value_ops.rs
+++ b/src/tui/state/field/state/value_ops.rs
@@ -15,6 +15,11 @@ impl FieldState {
         self.component.display_value(&self.schema)
     }
 
+    pub fn display_value_with_limit(&self, max_visible: usize) -> String {
+        self.component
+            .display_value_with_limit(&self.schema, max_visible)
+    }
+
     pub fn cursor_offset(&self) -> Option<usize> {
         self.component.cursor_offset(&self.schema)
     }

--- a/src/tui/state/key_value.rs
+++ b/src/tui/state/key_value.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use serde_json::{Map, Value};
+use unicode_width::UnicodeWidthStr;
 
 use crate::tui::model::{FieldKind, FieldSchema, KeyValueField};
 
@@ -9,7 +10,7 @@ use super::{
     field::{FieldState, components::ComponentPalette},
     form_state::FormState,
     section::SectionState,
-    value_summary::summarize_value,
+    value_summary::{summarize_value, summarize_value_with_limit},
 };
 
 #[derive(Debug, Clone)]
@@ -140,6 +141,17 @@ impl KeyValueState {
         Some(format!("{} = {}", entry.key, summarize_value(&entry.value)))
     }
 
+    pub fn selected_label_with_limit(&self, max_visible: usize) -> Option<String> {
+        let idx = self.selected_index()?;
+        let entry = self.entries.get(idx)?;
+        let prefix = format!("{} = ", entry.key);
+        let remaining = max_visible.saturating_sub(UnicodeWidthStr::width(prefix.as_str()));
+        Some(format!(
+            "{prefix}{}",
+            summarize_value_with_limit(&entry.value, remaining.max(1))
+        ))
+    }
+
     pub fn summaries(&self) -> Vec<String> {
         self.entries
             .iter()
@@ -147,9 +159,28 @@ impl KeyValueState {
             .collect()
     }
 
+    pub fn summaries_with_limit(&self, max_visible: usize) -> Vec<String> {
+        self.entries
+            .iter()
+            .map(|entry| {
+                let prefix = format!("{} = ", entry.key);
+                let remaining = max_visible.saturating_sub(UnicodeWidthStr::width(prefix.as_str()));
+                format!(
+                    "{prefix}{}",
+                    summarize_value_with_limit(&entry.value, remaining.max(1))
+                )
+            })
+            .collect()
+    }
+
     pub fn panel(&self) -> Option<(Vec<String>, usize)> {
         let idx = self.selected_index()?;
         Some((self.summaries(), idx))
+    }
+
+    pub fn panel_with_limit(&self, max_visible: usize) -> Option<(Vec<String>, usize)> {
+        let idx = self.selected_index()?;
+        Some((self.summaries_with_limit(max_visible), idx))
     }
 
     pub fn build_value(&self, required: bool) -> Result<Option<Value>, FieldCoercionError> {

--- a/src/tui/state/key_value.rs
+++ b/src/tui/state/key_value.rs
@@ -9,6 +9,7 @@ use super::{
     field::{FieldState, components::ComponentPalette},
     form_state::FormState,
     section::SectionState,
+    value_summary::summarize_value,
 };
 
 #[derive(Debug, Clone)]
@@ -335,33 +336,6 @@ impl KeyValueState {
                 return candidate;
             }
         }
-    }
-}
-
-pub(crate) fn summarize_value(value: &Value) -> String {
-    match value {
-        Value::Null => "null".to_string(),
-        Value::Bool(flag) => flag.to_string(),
-        Value::Number(num) => num.to_string(),
-        Value::String(text) => summarize_string(text),
-        Value::Array(items) => format!("array({})", items.len()),
-        Value::Object(map) => format!("object({})", map.len()),
-    }
-}
-
-fn summarize_string(text: &str) -> String {
-    use unicode_width::UnicodeWidthStr;
-    const MAX_VISIBLE: usize = 36;
-    const TRUNCATE_TO: usize = MAX_VISIBLE - 12;
-    let char_count = UnicodeWidthStr::width(text);
-    if char_count > MAX_VISIBLE {
-        let mut truncated = String::new();
-        for ch in text.chars().take(TRUNCATE_TO) {
-            truncated.push(ch);
-        }
-        format!("\"{}…\"", truncated)
-    } else {
-        format!("\"{text}\"")
     }
 }
 

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -9,6 +9,7 @@ pub mod layout_nav;
 pub mod reducers;
 pub mod section;
 pub mod ui_store;
+pub mod value_summary;
 
 pub use actions::FormCommand;
 pub use array::ArrayEditorSession;

--- a/src/tui/state/value_summary.rs
+++ b/src/tui/state/value_summary.rs
@@ -1,0 +1,106 @@
+use serde_json::{Map, Value};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+const MAX_STRING_VISIBLE: usize = 36;
+const MAX_INLINE_STRING_VISIBLE: usize = 24;
+const MAX_COLLECTION_ITEMS: usize = 3;
+const MAX_NESTED_DEPTH: usize = 2;
+
+pub(crate) fn summarize_value(value: &Value) -> String {
+    summarize_value_impl(value, 0, false)
+}
+
+pub(crate) fn summarize_inline_value(value: &Value) -> String {
+    summarize_value_impl(value, 0, true)
+}
+
+fn summarize_value_impl(value: &Value, depth: usize, inline_string: bool) -> String {
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(flag) => flag.to_string(),
+        Value::Number(num) => num.to_string(),
+        Value::String(text) => summarize_string(text, inline_string),
+        Value::Array(items) => summarize_array(items, depth),
+        Value::Object(map) => summarize_object(map, depth),
+    }
+}
+
+fn summarize_array(items: &[Value], depth: usize) -> String {
+    if items.is_empty() {
+        return "[]".to_string();
+    }
+    if depth >= MAX_NESTED_DEPTH {
+        return format!("[{} items]", items.len());
+    }
+
+    let mut parts = items
+        .iter()
+        .take(MAX_COLLECTION_ITEMS)
+        .map(|value| summarize_value_impl(value, depth + 1, true))
+        .collect::<Vec<_>>();
+    if items.len() > MAX_COLLECTION_ITEMS {
+        parts.push("…".to_string());
+    }
+    truncate_visible(&format!("[{}]", parts.join(", ")), MAX_STRING_VISIBLE)
+}
+
+fn summarize_object(map: &Map<String, Value>, depth: usize) -> String {
+    if map.is_empty() {
+        return "{}".to_string();
+    }
+    if depth >= MAX_NESTED_DEPTH {
+        return format!("{{{} keys}}", map.len());
+    }
+
+    let mut parts = map
+        .iter()
+        .take(MAX_COLLECTION_ITEMS)
+        .map(|(key, value)| format!("{key}: {}", summarize_value_impl(value, depth + 1, true)))
+        .collect::<Vec<_>>();
+    if map.len() > MAX_COLLECTION_ITEMS {
+        parts.push("…".to_string());
+    }
+    truncate_visible(&format!("{{ {} }}", parts.join(", ")), MAX_STRING_VISIBLE)
+}
+
+fn summarize_string(text: &str, inline: bool) -> String {
+    if inline {
+        truncate_visible(text, MAX_INLINE_STRING_VISIBLE)
+    } else {
+        format!("\"{}\"", truncate_display_string(text))
+    }
+}
+
+fn truncate_display_string(text: &str) -> String {
+    const TRUNCATE_TO: usize = MAX_STRING_VISIBLE - 12;
+    if UnicodeWidthStr::width(text) > MAX_STRING_VISIBLE {
+        let mut truncated = String::new();
+        for ch in text.chars().take(TRUNCATE_TO) {
+            truncated.push(ch);
+        }
+        truncated.push('…');
+        truncated
+    } else {
+        text.to_string()
+    }
+}
+
+fn truncate_visible(text: &str, max_visible: usize) -> String {
+    if UnicodeWidthStr::width(text) <= max_visible {
+        return text.to_string();
+    }
+
+    let mut out = String::new();
+    let mut width = 0usize;
+    let limit = max_visible.saturating_sub(1);
+    for ch in text.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if width + ch_width > limit {
+            break;
+        }
+        out.push(ch);
+        width += ch_width;
+    }
+    out.push('…');
+    out
+}

--- a/src/tui/state/value_summary.rs
+++ b/src/tui/state/value_summary.rs
@@ -14,6 +14,14 @@ pub(crate) fn summarize_inline_value(value: &Value) -> String {
     summarize_value_impl(value, 0, true)
 }
 
+pub(crate) fn summarize_value_with_limit(value: &Value, max_visible: usize) -> String {
+    summarize_value_limited_impl(value, 0, false, max_visible)
+}
+
+pub(crate) fn summarize_inline_value_with_limit(value: &Value, max_visible: usize) -> String {
+    summarize_value_limited_impl(value, 0, true, max_visible)
+}
+
 fn summarize_value_impl(value: &Value, depth: usize, inline_string: bool) -> String {
     match value {
         Value::Null => "null".to_string(),
@@ -83,6 +91,219 @@ fn truncate_display_string(text: &str) -> String {
     } else {
         text.to_string()
     }
+}
+
+pub(crate) fn truncate_visible_text(text: &str, max_visible: usize) -> String {
+    truncate_visible(text, max_visible)
+}
+
+fn summarize_value_limited_impl(
+    value: &Value,
+    depth: usize,
+    inline_string: bool,
+    max_visible: usize,
+) -> String {
+    if max_visible == 0 {
+        return String::new();
+    }
+
+    match value {
+        Value::Null => truncate_visible("null", max_visible),
+        Value::Bool(flag) => truncate_visible(&flag.to_string(), max_visible),
+        Value::Number(num) => truncate_visible(&num.to_string(), max_visible),
+        Value::String(text) => summarize_string_limited(text, inline_string, max_visible),
+        Value::Array(items) => summarize_array_limited(items, depth, max_visible),
+        Value::Object(map) => summarize_object_limited(map, depth, max_visible),
+    }
+}
+
+fn summarize_array_limited(items: &[Value], depth: usize, max_visible: usize) -> String {
+    if items.is_empty() {
+        return truncate_visible("[]", max_visible);
+    }
+    if depth >= MAX_NESTED_DEPTH {
+        return truncate_visible(&format!("[{} items]", items.len()), max_visible);
+    }
+
+    let entries = items.iter().take(MAX_COLLECTION_ITEMS).collect::<Vec<_>>();
+    let hidden = items.len().saturating_sub(entries.len());
+    summarize_sequence_limited(
+        "[",
+        "]",
+        ", ",
+        entries.len(),
+        hidden,
+        max_visible,
+        |index, budget| summarize_value_limited_impl(entries[index], depth + 1, true, budget),
+    )
+}
+
+fn summarize_object_limited(map: &Map<String, Value>, depth: usize, max_visible: usize) -> String {
+    if map.is_empty() {
+        return truncate_visible("{}", max_visible);
+    }
+    if depth >= MAX_NESTED_DEPTH {
+        return truncate_visible(&format!("{{{} keys}}", map.len()), max_visible);
+    }
+
+    let entries = map
+        .iter()
+        .take(MAX_COLLECTION_ITEMS)
+        .map(|(key, value)| (key.as_str(), value))
+        .collect::<Vec<_>>();
+    let hidden = map.len().saturating_sub(entries.len());
+
+    summarize_sequence_limited(
+        "{ ",
+        " }",
+        ", ",
+        entries.len(),
+        hidden,
+        max_visible,
+        |index, budget| {
+            let (key, value) = entries[index];
+            let prefix = format!("{key}: ");
+            let prefix_width = visible_width(&prefix);
+            if prefix_width >= budget {
+                return truncate_visible(&prefix, budget);
+            }
+            let value_budget = budget.saturating_sub(prefix_width);
+            let summary = summarize_value_limited_impl(value, depth + 1, true, value_budget);
+            format!("{prefix}{summary}")
+        },
+    )
+}
+
+fn summarize_sequence_limited<F>(
+    open: &str,
+    close: &str,
+    separator: &str,
+    total_entries: usize,
+    hidden_entries: usize,
+    max_visible: usize,
+    mut render_item: F,
+) -> String
+where
+    F: FnMut(usize, usize) -> String,
+{
+    let open_width = visible_width(open);
+    let close_width = visible_width(close);
+    let separator_width = visible_width(separator);
+    let ellipsis_width = visible_width("…");
+
+    if max_visible <= open_width + close_width {
+        let compact = format!(
+            "{}{}",
+            open.trim_end_matches(' '),
+            close.trim_start_matches(' ')
+        );
+        return truncate_visible(&compact, max_visible);
+    }
+
+    let full_items = (0..total_entries)
+        .map(|index| render_item(index, max_visible))
+        .collect::<Vec<_>>();
+    let full_widths = full_items
+        .iter()
+        .map(|item| visible_width(item))
+        .collect::<Vec<_>>();
+
+    let mut visible_entries = total_entries;
+    while visible_entries > 0 {
+        let show_ellipsis = hidden_entries > 0 || visible_entries < total_entries;
+        let ellipsis_block_width = if show_ellipsis {
+            separator_width + ellipsis_width
+        } else {
+            0
+        };
+        let fixed_width = open_width
+            + close_width
+            + separator_width * visible_entries.saturating_sub(1)
+            + ellipsis_block_width;
+        let min_value_width = full_widths
+            .iter()
+            .take(visible_entries)
+            .filter(|width| **width > 0)
+            .count();
+
+        if fixed_width + min_value_width <= max_visible {
+            let available_values = max_visible.saturating_sub(fixed_width);
+            let budgets =
+                allocate_visible_budgets(&full_widths[..visible_entries], available_values);
+            let mut out = String::from(open);
+            for index in 0..visible_entries {
+                if index > 0 {
+                    out.push_str(separator);
+                }
+                let item = if budgets[index] >= full_widths[index] {
+                    full_items[index].clone()
+                } else {
+                    render_item(index, budgets[index])
+                };
+                out.push_str(&item);
+            }
+            if show_ellipsis {
+                if visible_entries > 0 {
+                    out.push_str(separator);
+                }
+                out.push('…');
+            }
+            out.push_str(close);
+            return truncate_visible(&out, max_visible);
+        }
+
+        visible_entries -= 1;
+    }
+
+    truncate_visible(&format!("{open}…{close}"), max_visible)
+}
+
+fn allocate_visible_budgets(full_widths: &[usize], available: usize) -> Vec<usize> {
+    if full_widths.is_empty() {
+        return Vec::new();
+    }
+
+    let mut budgets = vec![0usize; full_widths.len()];
+    let mut remaining_available = available;
+    let mut remaining_items = full_widths.len();
+
+    for (index, full_width) in full_widths.iter().enumerate() {
+        if remaining_items == 0 {
+            break;
+        }
+        let share = remaining_available / remaining_items;
+        let minimum = usize::from(*full_width > 0);
+        let budget = (*full_width).min(share.max(minimum));
+        budgets[index] = budget;
+        remaining_available = remaining_available.saturating_sub(budget);
+        remaining_items -= 1;
+    }
+
+    for (budget, full_width) in budgets.iter_mut().zip(full_widths.iter()) {
+        if remaining_available == 0 {
+            break;
+        }
+        let extra = full_width.saturating_sub(*budget).min(remaining_available);
+        *budget += extra;
+        remaining_available -= extra;
+    }
+
+    budgets
+}
+
+fn summarize_string_limited(text: &str, inline: bool, max_visible: usize) -> String {
+    if inline {
+        truncate_visible(text, max_visible)
+    } else if max_visible <= 2 {
+        truncate_visible("\"\"", max_visible)
+    } else {
+        let inner = truncate_visible(text, max_visible.saturating_sub(2));
+        format!("\"{inner}\"")
+    }
+}
+
+fn visible_width(text: &str) -> usize {
+    UnicodeWidthStr::width(text)
 }
 
 fn truncate_visible(text: &str, max_visible: usize) -> String {

--- a/src/tui/view/components/fields.rs
+++ b/src/tui/view/components/fields.rs
@@ -53,9 +53,13 @@ pub fn render_fields(
         return;
     }
 
-    let content_width = field_area
+    let value_panel_width = field_area
         .width
         .saturating_sub(8 + highlight_symbol_width());
+    let text_line_width = value_panel_width.saturating_add(
+        (UnicodeWidthStr::width(VALUE_BORDER_PREFIX) + UnicodeWidthStr::width(VALUE_BORDER_SUFFIX))
+            as u16,
+    );
     let mut items = Vec::with_capacity(section.fields.len());
     let mut cursor_hint: Option<CursorHint> = None;
     let mut field_heights = Vec::with_capacity(section.fields.len());
@@ -63,7 +67,12 @@ pub fn render_fields(
     let viewport_top = section.scroll_offset;
 
     for (idx, field) in section.fields.iter().enumerate() {
-        let render = build_field_render(field, idx == selected_index, content_width);
+        let render = build_field_render(
+            field,
+            idx == selected_index,
+            value_panel_width,
+            text_line_width,
+        );
         if idx == selected_index
             && let Some(hint) = render.cursor_hint
         {
@@ -157,12 +166,17 @@ struct CursorHint {
     column_offset: u16,
 }
 
-fn build_field_render(field: &FieldState, is_selected: bool, max_width: u16) -> FieldRender {
+fn build_field_render(
+    field: &FieldState,
+    is_selected: bool,
+    value_width: u16,
+    text_width: u16,
+) -> FieldRender {
     let mut lines = Vec::new();
     lines.push(info_line(field, is_selected));
-    let (value_panel, cursor_hint) = value_panel_lines(field, is_selected, max_width);
+    let (value_panel, cursor_hint) = value_panel_lines(field, is_selected, value_width);
     lines.extend(value_panel);
-    lines.extend(meta_lines(field, is_selected, max_width));
+    lines.extend(meta_lines(field, is_selected, text_width));
 
     if is_selected {
         if let Some(selector_lines) = composite_selector_lines(field) {
@@ -173,12 +187,12 @@ fn build_field_render(field: &FieldState, is_selected: bool, max_width: u16) -> 
             lines.extend(summary);
         }
 
-        if let Some(summary) = repeatable_summary_lines(field) {
+        if let Some(summary) = repeatable_summary_lines(field, text_width) {
             lines.extend(summary);
         }
     }
 
-    if let Some(error) = error_lines(field, max_width) {
+    if let Some(error) = error_lines(field, text_width) {
         lines.extend(error);
     }
 
@@ -222,7 +236,7 @@ fn value_panel_lines(
     max_width: u16,
 ) -> (Vec<Line<'static>>, Option<CursorHint>) {
     let clamp_width = max_width.max(4) as usize;
-    let value_text = field.display_value();
+    let value_text = field.display_value_with_limit(clamp_width.saturating_mul(3));
     let cursor_offset = field
         .cursor_offset()
         .unwrap_or_else(|| value_text.chars().count());
@@ -530,8 +544,13 @@ fn composite_summary_lines(field: &FieldState) -> Option<Vec<Line<'static>>> {
     Some(lines)
 }
 
-fn repeatable_summary_lines(field: &FieldState) -> Option<Vec<Line<'static>>> {
-    if let Some((entries, selected)) = field.composite_list_panel() {
+fn repeatable_summary_lines(field: &FieldState, max_width: u16) -> Option<Vec<Line<'static>>> {
+    let entry_prefix = "  » ";
+    let entry_width = max_width
+        .saturating_sub(UnicodeWidthStr::width(entry_prefix) as u16)
+        .max(1) as usize;
+
+    if let Some((entries, selected)) = field.composite_list_panel_with_limit(entry_width) {
         if entries.is_empty() {
             return None;
         }
@@ -540,7 +559,10 @@ fn repeatable_summary_lines(field: &FieldState) -> Option<Vec<Line<'static>>> {
         let max_render = 4usize;
         for (idx, entry) in entries.iter().enumerate().take(max_render) {
             let marker = if idx == selected { "»" } else { " " };
-            lines.push(Line::from(format!("  {marker} {entry}")));
+            lines.push(Line::from(format!(
+                "  {marker} {}",
+                truncate_line(entry, entry_width)
+            )));
         }
         if entries.len() > max_render {
             lines.push(Line::from(format!(
@@ -778,6 +800,16 @@ fn truncate_line_with_ellipsis(line: &mut String, max_width: usize) {
     }
 }
 
+fn truncate_line(line: &str, max_width: usize) -> String {
+    if UnicodeWidthStr::width(line) <= max_width {
+        return line.to_string();
+    }
+
+    let mut owned = line.to_string();
+    truncate_line_with_ellipsis(&mut owned, max_width);
+    owned
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -808,7 +840,7 @@ mod tests {
     #[test]
     fn cursor_hint_includes_border_and_highlight_width() {
         let field = field_with_value("汉字");
-        let render = build_field_render(&field, true, 10);
+        let render = build_field_render(&field, true, 10, 12);
         let hint = render
             .cursor_hint
             .expect("cursor hint present for selected field");

--- a/src/tui/view/components/fields.rs
+++ b/src/tui/view/components/fields.rs
@@ -333,7 +333,7 @@ pub(crate) fn meta_lines(
     wrap_with_prefix(&content, "  ", max_width, style, style)
 }
 
-fn error_lines(field: &FieldState, max_width: u16) -> Option<Vec<Line<'static>>> {
+pub(crate) fn error_lines(field: &FieldState, max_width: u16) -> Option<Vec<Line<'static>>> {
     field.error.as_ref().map(|message| {
         let mut lines = Vec::new();
         lines.push(Line::from(Span::styled(
@@ -341,12 +341,13 @@ fn error_lines(field: &FieldState, max_width: u16) -> Option<Vec<Line<'static>>>
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
         )));
         let error_style = Style::default().fg(Color::Red);
-        lines.extend(wrap_with_prefix(
+        lines.extend(wrap_with_prefix_limited(
             message,
             "    ",
             max_width,
             error_style,
             error_style,
+            3,
         ));
         lines
     })
@@ -718,6 +719,63 @@ fn wrap_with_prefix(
             ])
         })
         .collect()
+}
+
+fn wrap_with_prefix_limited(
+    text: &str,
+    prefix: &str,
+    max_width: u16,
+    prefix_style: Style,
+    content_style: Style,
+    max_lines: usize,
+) -> Vec<Line<'static>> {
+    let prefix_width = UnicodeWidthStr::width(prefix) as u16;
+    let available = max_width.saturating_sub(prefix_width).max(1) as usize;
+    let mut wrapped = wrap_preserving_spaces(text, available);
+    if wrapped.len() > max_lines {
+        wrapped.truncate(max_lines);
+        if let Some(last) = wrapped.last_mut() {
+            truncate_line_with_ellipsis(last, available);
+        }
+    }
+
+    wrapped
+        .into_iter()
+        .map(|segment| {
+            Line::from(vec![
+                Span::styled(prefix.to_string(), prefix_style),
+                Span::styled(segment, content_style),
+            ])
+        })
+        .collect()
+}
+
+fn truncate_line_with_ellipsis(line: &mut String, max_width: usize) {
+    if max_width == 0 {
+        line.clear();
+        line.push('…');
+        return;
+    }
+
+    let current_width = UnicodeWidthStr::width(line.as_str());
+    if current_width >= max_width {
+        let mut truncated = String::new();
+        let limit = max_width.saturating_sub(1);
+        let mut width = 0usize;
+        for ch in line.chars() {
+            let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if width + ch_width > limit {
+                break;
+            }
+            truncated.push(ch);
+            width += ch_width;
+        }
+        *line = truncated;
+    }
+
+    if !line.ends_with('…') {
+        line.push('…');
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR fixes a few UX issues in both CLI and TUI:

- report missing `-c` config files correctly instead of surfacing a misleading root schema error
- render object previews in TUI entry summaries
- use dynamic width truncation for TUI summaries so important fields like `Bar` and `Id` stay visible when possible
- keep the top list value compact and show detailed object previews only in the `Entries` summary
- wrap TUI validation errors automatically, capped at 3 lines

Close #116 

<img width="1445" height="236" alt="CleanShot 2026-04-30 at 13 03 27" src="https://github.com/user-attachments/assets/528a7120-48a7-490c-ae4f-531121650160" />
