### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+
+## [0.11.1](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.11.0...schemaui-v0.11.1) - 2026-04-30
+
+
+
+
+
+
+### Bug Fixes
+
+- make terminal UI dependencies optional([#123](https://github.com/YuniqueUnic/schemaui/pull/123), @YuniqueUnic)
+
+
+
+
+
+
+
+
+
+
+
+
+### Contributors
+
+- @YuniqueUnic
+
+
 ## [0.11.0](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.10.3...schemaui-v0.11.0) - 2026-04-30
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "schemaui"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "schemaui-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["schemaui-cli"]
 [package]
 name = "schemaui"
 authors = ["unic <yuniqueunic@gmail.com>"]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 keywords = ["tui", "schema", "configuration", "terminal", "cross-platform"]
 categories = ["command-line-interface", "config"]

--- a/README.ZH.md
+++ b/README.ZH.md
@@ -92,7 +92,7 @@ stdin/内联文本，则回退到当前工作目录。对于 JSON 配置，根�
 
 ```toml
 [dependencies]
-schemaui = "0.11.0"
+schemaui = "0.11.1"
 serde_json = "1"
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ References:
 
 ```toml
 [dependencies]
-schemaui = "0.11.0"
+schemaui = "0.11.1"
 serde_json = "1"
 ```
 

--- a/schemaui-cli/CHANGELOG.md
+++ b/schemaui-cli/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [0.7.1](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.7.0...schemaui-cli-v0.7.1) - 2026-04-30
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+### Other
+
+- updated the following local packages: schemaui
+
+
+
+
 ## [0.7.0](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.6.1...schemaui-cli-v0.7.0) - 2026-04-30
 
 

--- a/schemaui-cli/Cargo.toml
+++ b/schemaui-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schemaui-cli"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 authors = ["unic <yuniqueunic@gmail.com>"]
 description = "CLI wrapper for schemaui, rendering JSON Schemas as TUIs"
@@ -25,7 +25,7 @@ name = "schemaui"
 path = "src/main.rs"
 
 [dependencies]
-schemaui = { path = "..", version = "0.11.0", default-features = false }
+schemaui = { path = "..", version = "0.11.1", default-features = false }
 serde_json = "1"
 color-eyre = "0.6"
 clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context"] }


### PR DESCRIPTION



## 🤖 New release

* `schemaui`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `schemaui-cli`: 0.7.0 -> 0.7.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `schemaui`

<blockquote>

## [0.11.1](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.11.0...schemaui-v0.11.1) - 2026-04-30

### Bug Fixes

- make terminal UI dependencies optional([#123](https://github.com/YuniqueUnic/schemaui/pull/123), @YuniqueUnic)












### Contributors

- @YuniqueUnic
</blockquote>

## `schemaui-cli`

<blockquote>

## [0.7.1](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.7.0...schemaui-cli-v0.7.1) - 2026-04-30

### Other

- updated the following local packages: schemaui
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).