### PR TITLE
refactor(cli): replace eyre with anyhow for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,16 +468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
 name = "fancy-regex"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,12 +826,6 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
-
-[[package]]
-name = "indenter"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -1511,10 +1495,10 @@ dependencies = [
 name = "schemaui-cli"
 version = "0.7.1"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "clap",
  "clap_complete",
- "eyre",
  "predicates",
  "schemaui",
  "serde_json",

--- a/README.ZH.md
+++ b/README.ZH.md
@@ -97,11 +97,11 @@ serde_json = "1"
 ```
 
 ```rust
+use anyhow::Result;
 use schemaui::prelude::*;
 use serde_json::json;
 
-fn main() -> color_eyre::Result<()> {
-    color_eyre::install()?;
+fn main() -> Result<()> {
     let schema = json!({
         "$schema": "http://json-schema.org/draft-07/schema# ",
         "title": "服务运行时",
@@ -459,7 +459,7 @@ schemaui \
 ```
 
 ```
-┌────────┐  argh args   ┌──────────────┐ read stdin/files ┌─────────────┐
+┌────────┐  clap args   ┌──────────────┐ read stdin/files ┌─────────────┐
 │  CLI   ├─────────────▶│ InputSource  ├─────────────────▶│ io::input   │
 └────┬───┘              └──────┬───────┘                  └────┬────────┘
      │ diagnostics             │ schema/default Value          │
@@ -488,9 +488,8 @@ schemaui \
 - 标志 – `--no-pretty`切换紧凑输出，`--force/--yes`允许覆盖文件，`--title` /
   `--description`分别传递到`SchemaUI::with_title` /
   `SchemaUI::with_description`。
-- Shell completion – `schemaui completion <bash|zsh|fish|nushell>` 会从同一套
-  `argh` 命令树生成补全脚本。PowerShell 暂未暴露，因为上游 `argh_complete`
-  目前没有提供 PowerShell generator。
+- Shell completion – `schemaui completion <bash|zsh|fish|powershell>` 会通过
+  `clap_complete` 从同一套 `clap` 命令树生成补全脚本。
 
 ## 关键依赖项
 
@@ -503,7 +502,7 @@ schemaui \
 | `crossterm`                                 | 输入路由器消耗的终端事件。                |
 | `indexmap`                                  | 模式遍历的顺序保持映射。                  |
 | `once_cell`                                 | 懒解析快捷键 JSON。                       |
-| `argh`, `argh_complete`, `color-eyre` (CLI) | 参数解析、Shell 补全生成和友好的诊断。    |
+| `clap`, `clap_complete`, `anyhow` (CLI)     | 参数解析、Shell 补全生成和友好的诊断。    |
 
 ## 文档映射
 

--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ serde_json = "1"
 ```
 
 ```rust,ignore
+use anyhow::Result;
 use schemaui::prelude::*;
 use serde_json::json;
 
-fn main() -> color_eyre::Result<()> {
-    color_eyre::install()?;
+fn main() -> Result<()> {
     let schema = json!({
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Service Runtime",
@@ -545,7 +545,7 @@ schemaui \
 ```
 
 ```text
-┌────────┐  argh args   ┌──────────────┐ read stdin/files ┌─────────────┐
+┌────────┐  clap args   ┌──────────────┐ read stdin/files ┌─────────────┐
 │  CLI   ├─────────────▶│ InputSource  ├─────────────────▶│ io::input   │
 └────┬───┘              └──────┬───────┘                  └────┬────────┘
      │ diagnostics             │ schema/default Value          │
@@ -575,10 +575,8 @@ schemaui \
 - Flags – `--no-pretty` toggles compact output, `--force/--yes` allows
   overwriting files, and `--title` / `--description` wire through to
   `SchemaUI::with_title` / `SchemaUI::with_description`.
-- Shell completion – `schemaui completion <bash|zsh|fish|nushell>` emits
-  completion scripts from the same `argh` command graph. PowerShell is not
-  exposed yet because upstream `argh_complete` does not currently ship a
-  PowerShell generator.
+- Shell completion – `schemaui completion <bash|zsh|fish|powershell>` emits
+  completion scripts from the same `clap` command graph via `clap_complete`.
 
 ## Key Dependencies
 
@@ -591,7 +589,7 @@ schemaui \
 | `crossterm`                                 | Terminal events consumed by `InputRouter`.                     |
 | `indexmap`                                  | Order-preserving maps for schema traversal.                    |
 | `once_cell`                                 | Lazy parsing of the keymap JSON.                               |
-| `argh`, `argh_complete`, `color-eyre` (CLI) | Argument parsing, shell completion, and ergonomic diagnostics. |
+| `clap`, `clap_complete`, `anyhow` (CLI)     | Argument parsing, shell completion, and ergonomic diagnostics. |
 
 ## Documentation Map
 

--- a/schemaui-cli/Cargo.toml
+++ b/schemaui-cli/Cargo.toml
@@ -27,23 +27,34 @@ path = "src/main.rs"
 [dependencies]
 schemaui = { path = "..", version = "0.11.1", default-features = false }
 serde_json = "1"
-eyre = "0.6"
-clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context"] }
+anyhow = "1"
+clap = { version = "4", default-features = false, features = [
+    "derive",
+    "std",
+    "help",
+    "usage",
+    "error-context",
+] }
 clap_complete = { version = "4", optional = true }
-ureq = { version = "3", default-features = false, features = ["rustls"], optional = true }
+ureq = { version = "3", default-features = false, features = [
+    "rustls",
+], optional = true }
 url = "2"
 
 [features]
-default = ["full", "remote-schema"]
-completion = ["dep:clap_complete"]
-tui = ["schemaui/tui"]
+default = ["full", "completion", "remote-schema"]
+
 full = ["json", "yaml", "toml", "tui", "web"]
+completion = ["dep:clap_complete"]
+remote-schema = ["dep:ureq"]
+
+tui = ["schemaui/tui"]
+web = ["schemaui/web"]
 json = ["schemaui/json"]
 yaml = ["schemaui/yaml"]
 toml = ["schemaui/toml"]
-web = ["schemaui/web"]
+
 web-types = ["schemaui/web-types"]
-remote-schema = ["dep:ureq"]
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/schemaui-cli/src/completion.rs
+++ b/schemaui-cli/src/completion.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
+use anyhow::Result;
 use clap_complete::{Shell, generate};
-use eyre::Result;
 
 use crate::cli::{CompletionCommand, CompletionShell, command_info};
 

--- a/schemaui-cli/src/io.rs
+++ b/schemaui-cli/src/io.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
-use eyre::{Report, Result, WrapErr};
+use anyhow::{Context, Result, anyhow};
 use schemaui::{DocumentFormat, parse_document_str};
 use serde_json::Value;
 
@@ -26,7 +26,7 @@ pub fn load_value(spec: &str, format: DocumentFormat, label: &str) -> Result<Val
                 let inline_label = format!("inline {label}");
                 return parse_contents(spec, format, &inline_label);
             }
-            Err(err.wrap_err(format!("failed to load {label} from {}", path.display())))
+            Err(err.context(format!("failed to load {label} from {}", path.display())))
         }
     }
 }
@@ -37,11 +37,11 @@ fn read_from_source(source: &InputSource) -> Result<String> {
             let mut buffer = String::new();
             io::stdin()
                 .read_to_string(&mut buffer)
-                .wrap_err("failed to read from stdin")?;
+                .context("failed to read from stdin")?;
             Ok(buffer)
         }
         InputSource::File(path) => fs::read_to_string(path)
-            .wrap_err_with(|| format!("failed to read file {}", path.display())),
+            .with_context(|| format!("failed to read file {}", path.display())),
     }
 }
 
@@ -57,15 +57,15 @@ fn parse_contents(contents: &str, format: DocumentFormat, label: &str) -> Result
                     return Ok(value);
                 }
             }
-            Err(Report::msg(format!(
+            Err(anyhow!(
                 "failed to parse {label}: tried {} (first error: {primary})",
                 DocumentFormat::format_list()
-            )))
+            ))
         }
     }
 }
 
-pub fn is_not_found(err: &Report) -> bool {
+pub fn is_not_found(err: &anyhow::Error) -> bool {
     err.downcast_ref::<io::Error>()
         .is_some_and(|io_err| io_err.kind() == io::ErrorKind::NotFound)
 }

--- a/schemaui-cli/src/main.rs
+++ b/schemaui-cli/src/main.rs
@@ -1,8 +1,8 @@
 #![doc = include_str!("../cli_usage.md")]
 
+use anyhow::Result;
 #[cfg(not(feature = "tui"))]
 use clap::CommandFactory;
-use eyre::Result;
 
 use schemaui_cli::cli::Cli;
 #[cfg(any(feature = "completion", feature = "tui", feature = "web"))]
@@ -39,7 +39,7 @@ fn main() -> Result<()> {
             let mut cmd = Cli::command();
             cmd.print_help()?;
             println!();
-            Err(eyre::eyre!(
+            Err(anyhow::anyhow!(
                 "this schemaui-cli build does not include the `tui` feature; use a subcommand supported by the active feature set"
             ))
         }

--- a/schemaui-cli/src/session/builder.rs
+++ b/schemaui-cli/src/session/builder.rs
@@ -1,4 +1,4 @@
-use eyre::{Result, eyre};
+use anyhow::{Result, anyhow};
 
 use crate::cli::CommonArgs;
 
@@ -51,7 +51,7 @@ pub fn prepare_session(args: &CommonArgs) -> Result<SessionBundle> {
     diagnostics.into_result()?;
 
     if schema_document.is_none() && config_document.is_none() {
-        return Err(eyre!("provide at least --schema or --config"));
+        return Err(anyhow!("provide at least --schema or --config"));
     }
     let resolved = resolve_session_inputs(schema_document, config_document)?;
 

--- a/schemaui-cli/src/session/diagnostics.rs
+++ b/schemaui-cli/src/session/diagnostics.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write as FmtWrite;
 
-use eyre::{Result, eyre};
+use anyhow::{Result, anyhow};
 
 #[derive(Debug, Default)]
 pub struct DiagnosticCollector {
@@ -28,6 +28,6 @@ impl DiagnosticCollector {
         for (idx, msg) in self.messages.iter().enumerate() {
             let _ = writeln!(body, "  {}. {}", idx + 1, msg);
         }
-        Err(eyre!(body))
+        Err(anyhow!(body))
     }
 }

--- a/schemaui-cli/src/session/schema_source.rs
+++ b/schemaui-cli/src/session/schema_source.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 #[cfg(feature = "remote-schema")]
 use std::time::Duration;
 
-use eyre::{Report, Result, WrapErr, eyre};
+use anyhow::{Context, Result, anyhow};
 use schemaui::{
     DocumentFormat, DocumentFormatProbe, looks_like_json_schema, parse_document_str,
     schema_from_data_value,
@@ -106,13 +106,11 @@ pub(crate) fn load_document(
                     origin: DocumentOrigin::Inline,
                 })
             } else {
-                Err(Report::new(err)
-                    .wrap_err(format!("failed to load {label} from {}", path.display())))
+                Err(anyhow!(err).context(format!("failed to load {label} from {}", path.display())))
             }
         }
         Err(err) => {
-            Err(Report::new(err)
-                .wrap_err(format!("failed to load {label} from {}", path.display())))
+            Err(anyhow!(err).context(format!("failed to load {label} from {}", path.display())))
         }
     }
 }
@@ -146,7 +144,7 @@ pub(crate) fn resolve_session_inputs(
     } else if let Some(config) = config.as_ref() {
         schema_from_data_value(&config.value)
     } else {
-        return Err(eyre!("provide at least --schema or --config"));
+        return Err(anyhow!("provide at least --schema or --config"));
     };
 
     Ok(ResolvedSessionInputs {
@@ -187,7 +185,7 @@ fn load_schema_reference(reference: &str, base: Option<&DocumentOrigin>) -> Resu
     match location {
         ReferenceLocation::File(path) => {
             let raw = fs::read_to_string(&path)
-                .wrap_err_with(|| format!("failed to read schema file {}", path.display()))?;
+                .with_context(|| format!("failed to read schema file {}", path.display()))?;
             parse_contents(&raw, format, "schema")
         }
         ReferenceLocation::Url(url) => {
@@ -206,7 +204,7 @@ fn resolve_schema_reference(
             "file" => {
                 let path = url
                     .to_file_path()
-                    .map_err(|_| eyre!("invalid file:// schema reference: {url}"))?;
+                    .map_err(|_| anyhow!("invalid file:// schema reference: {url}"))?;
                 Ok(ReferenceLocation::File(path))
             }
             _ => Ok(ReferenceLocation::Url(url)),
@@ -227,18 +225,18 @@ fn resolve_schema_reference(
         Some(DocumentOrigin::Url(url)) => {
             let joined = url
                 .join(reference)
-                .wrap_err_with(|| format!("failed to resolve schema reference '{reference}'"))?;
+                .with_context(|| format!("failed to resolve schema reference '{reference}'"))?;
             if joined.scheme() == "file" {
                 let path = joined
                     .to_file_path()
-                    .map_err(|_| eyre!("invalid file:// schema reference: {joined}"))?;
+                    .map_err(|_| anyhow!("invalid file:// schema reference: {joined}"))?;
                 Ok(ReferenceLocation::File(path))
             } else {
                 Ok(ReferenceLocation::Url(joined))
             }
         }
         Some(DocumentOrigin::Inline) | Some(DocumentOrigin::Stdin) | None => {
-            let cwd = env::current_dir().wrap_err("failed to resolve current working directory")?;
+            let cwd = env::current_dir().context("failed to resolve current working directory")?;
             Ok(ReferenceLocation::File(cwd.join(reference_path)))
         }
     }
@@ -261,7 +259,7 @@ fn format_for_reference_location(location: &ReferenceLocation) -> Result<Documen
         DocumentFormatProbe::UnsupportedFeature {
             format_name,
             feature_flag,
-        } => Err(eyre!(
+        } => Err(anyhow!(
             "schema reference {} requires {format_name} support, but this build lacks the '{feature_flag}' feature",
             reference_location_label(location)
         )),
@@ -367,9 +365,9 @@ fn load_document_from_url(url: Url, format: DocumentFormat, label: &str) -> Resu
         "file" => {
             let path = url
                 .to_file_path()
-                .map_err(|_| eyre!("invalid file:// URL for {label}: {url}"))?;
+                .map_err(|_| anyhow!("invalid file:// URL for {label}: {url}"))?;
             let raw = fs::read_to_string(&path)
-                .wrap_err_with(|| format!("failed to read {label} file {}", path.display()))?;
+                .with_context(|| format!("failed to read {label} file {}", path.display()))?;
             let value = parse_contents(&raw, format, label)?;
             Ok(LoadedDocument {
                 value,
@@ -391,10 +389,10 @@ fn load_document_from_url(url: Url, format: DocumentFormat, label: &str) -> Resu
             let mut response = client
                 .get(url.as_str())
                 .call()
-                .wrap_err_with(|| format!("failed to fetch {label} from {url}"))?;
+                .with_context(|| format!("failed to fetch {label} from {url}"))?;
             let status = response.status();
             if !status.is_success() {
-                return Err(eyre!(
+                return Err(anyhow!(
                     "failed to fetch {label} from {url}: HTTP {}",
                     status.as_u16()
                 ));
@@ -402,7 +400,7 @@ fn load_document_from_url(url: Url, format: DocumentFormat, label: &str) -> Resu
             let raw = response
                 .body_mut()
                 .read_to_string()
-                .wrap_err_with(|| format!("failed to read {label} response body from {url}"))?;
+                .with_context(|| format!("failed to read {label} response body from {url}"))?;
             let value = parse_contents(&raw, format, label)?;
             Ok(LoadedDocument {
                 value,
@@ -416,10 +414,10 @@ fn load_document_from_url(url: Url, format: DocumentFormat, label: &str) -> Resu
             })
         }
         #[cfg(not(feature = "remote-schema"))]
-        "http" | "https" => Err(eyre!(
+        "http" | "https" => Err(anyhow!(
             "remote schema support is disabled in this build; re-enable the 'remote-schema' feature to load {label} from {url}"
         )),
-        _ => Err(eyre!("unsupported URL scheme for {label}: {url}")),
+        _ => Err(anyhow!("unsupported URL scheme for {label}: {url}")),
     }
 }
 
@@ -468,7 +466,7 @@ fn read_stdin() -> Result<String> {
     let mut buffer = String::new();
     io::stdin()
         .read_to_string(&mut buffer)
-        .wrap_err("failed to read from stdin")?;
+        .context("failed to read from stdin")?;
     Ok(buffer)
 }
 
@@ -484,7 +482,7 @@ fn parse_contents(contents: &str, format: DocumentFormat, label: &str) -> Result
                     return Ok(value);
                 }
             }
-            Err(eyre!(
+            Err(anyhow!(
                 "failed to parse {label}: tried {} (first error: {primary})",
                 DocumentFormat::format_list()
             ))

--- a/schemaui-cli/src/tui/mod.rs
+++ b/schemaui-cli/src/tui/mod.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use eyre::{Report, Result};
+use anyhow::Result;
 use schemaui::SchemaUI;
 use schemaui::precompile::tui as pre_tui;
 
@@ -34,9 +34,9 @@ pub(crate) fn execute_session(session: SessionBundle) -> Result<()> {
     if let Some(description) = description {
         ui = ui.with_description(description);
     }
-    let value = ui.run_tui().map_err(Report::msg)?;
+    let value = ui.run_tui()?;
     if let Some(options) = output {
-        options.write(&value).map_err(Report::msg)?;
+        options.write(&value)?;
     }
     Ok(())
 }
@@ -70,7 +70,7 @@ pub fn run_snapshot_cli(cmd: TuiSnapshotCommand) -> Result<()> {
         &mut diagnostics,
     );
     diagnostics.into_result()?;
-    let resolved = resolve_session_inputs(schema_document, config_document).map_err(Report::msg)?;
+    let resolved = resolve_session_inputs(schema_document, config_document)?;
 
     fs::create_dir_all(&cmd.out_dir)?;
     let tui_module = cmd.out_dir.join("tui_artifacts.rs");
@@ -82,22 +82,19 @@ pub fn run_snapshot_cli(cmd: TuiSnapshotCommand) -> Result<()> {
         resolved.defaults.as_ref(),
         &tui_module,
         &cmd.tui_fn,
-    )
-    .map_err(Report::msg)?;
+    )?;
     pre_tui::generate_tui_form_schema_module_from_value(
         &resolved.schema,
         resolved.defaults.as_ref(),
         &form_module,
         &cmd.form_fn,
-    )
-    .map_err(Report::msg)?;
+    )?;
     pre_tui::generate_tui_layout_nav_module_from_value(
         &resolved.schema,
         resolved.defaults.as_ref(),
         &layout_module,
         &cmd.layout_fn,
-    )
-    .map_err(Report::msg)?;
+    )?;
 
     eprintln!("Generated TUI artifact modules:");
     eprintln!("  TuiArtifacts module:    {:?}", tui_module);

--- a/schemaui-cli/src/web/mod.rs
+++ b/schemaui-cli/src/web/mod.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use eyre::{Report, Result};
+use anyhow::Result;
 use schemaui::SchemaUI;
 use schemaui::precompile::web::{
     build_session_snapshot, write_session_snapshot_json, write_session_snapshot_ts_module,
@@ -44,9 +44,9 @@ fn execute_web_session(session: SessionBundle, cmd: WebCommand) -> Result<()> {
         port: cmd.port,
     };
 
-    let value = ui.run_web(serve).map_err(Report::msg)?;
+    let value = ui.run_web(serve)?;
     if let Some(options) = output {
-        options.write(&value).map_err(Report::msg)?;
+        options.write(&value)?;
     }
     Ok(())
 }
@@ -80,9 +80,8 @@ pub fn run_snapshot_cli(cmd: WebSnapshotCommand) -> Result<()> {
         &mut diagnostics,
     );
     diagnostics.into_result()?;
-    let resolved = resolve_session_inputs(schema_document, config_document).map_err(Report::msg)?;
-    let mut snapshot = build_session_snapshot(&resolved.schema, resolved.defaults.as_ref())
-        .map_err(Report::msg)?;
+    let resolved = resolve_session_inputs(schema_document, config_document)?;
+    let mut snapshot = build_session_snapshot(&resolved.schema, resolved.defaults.as_ref())?;
     if let Some(title) = cmd.common.title {
         snapshot.title = Some(title);
     }
@@ -94,8 +93,8 @@ pub fn run_snapshot_cli(cmd: WebSnapshotCommand) -> Result<()> {
     let json_out = cmd.out_dir.join("session_snapshot.json");
     let ts_out = cmd.out_dir.join("session_snapshot.ts");
 
-    write_session_snapshot_json(&snapshot, &json_out).map_err(Report::msg)?;
-    write_session_snapshot_ts_module(&snapshot, &ts_out, &cmd.ts_export).map_err(Report::msg)?;
+    write_session_snapshot_json(&snapshot, &json_out)?;
+    write_session_snapshot_ts_module(&snapshot, &ts_out, &cmd.ts_export)?;
 
     eprintln!("Generated Web precompile snapshots:");
     eprintln!("  JSON:      {:?}", json_out);


### PR DESCRIPTION
- Remove eyre dependency and replace with anyhow throughout the CLI
- Update Cargo.toml to remove eyre and add anyhow dependency
- Replace all eyre::Result with anyhow::Result imports
- Change Report::msg to anyhow! macro calls
- Replace wrap_err/wrap_err_with with context/with_context methods
- Update is_not_found function to accept anyhow::Error type

fix(cli): add completion feature as default option

- Add completion feature as part of default feature set
- Reorder features in logical grouping (full, completion, remote-schema)