### PR TITLE
fix(web): add configurable title to frontend output message

### DIFF
--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -14,13 +14,10 @@ pub mod value_summary;
 pub use actions::FormCommand;
 pub use array::ArrayEditorSession;
 pub use composite::CompositeEditorSession;
-#[allow(unused_imports)]
 pub use composite::CompositeState;
-#[allow(unused_imports)]
 pub use error::FieldCoercionError;
 pub use field::{CompositePopupData, FieldState};
 pub use form_state::FormState;
-#[allow(unused_imports)]
 pub use form_state::RootSectionState;
 pub use key_value::KeyValueEditorSession;
 pub use layout_nav::LayoutNavModel;

--- a/src/web/assets.rs
+++ b/src/web/assets.rs
@@ -63,8 +63,7 @@ impl WebAssetProvider for FilesystemAssets {
 }
 
 pub fn embedded_asset(path: &str) -> Option<AssetResponse> {
-    #[allow(clippy::default_constructed_unit_structs)]
-    EmbeddedAssets::default().load(path)
+    EmbeddedAssets.load(path)
 }
 
 fn normalize_path(raw: &str) -> &str {

--- a/src/web/frontend.rs
+++ b/src/web/frontend.rs
@@ -17,11 +17,12 @@ pub struct WebFrontend {
 impl WebFrontend {
     pub async fn run_async(self, ctx: FrontendContext) -> Result<Value> {
         let config = web_session_config(ctx);
+        let title = &config.title.clone().unwrap_or_default();
         let bound = bind_session(config, self.serve)
             .await
             .context("failed to bind web session")?;
         let addr = bound.local_addr();
-        eprintln!("schemaui web UI available at http://{addr}/");
+        eprintln!("{title} schemaui UI available at http://{addr}/");
         eprintln!("Press Ctrl+C to abort the session.");
         bound.run().await.context("web UI session failed")
     }


### PR DESCRIPTION
fix(web): add configurable title to frontend output message

Add title configuration to web frontend output message so it displays the configured title instead of generic "schemaui web UI".

refactor(tui): remove unnecessary allow unused imports attributes

Remove redundant #[allow(unused_imports)] attributes from module exports in src/tui/state/mod.rs as they are no longer needed.

refactor(web): simplify embedded asset loading implementation

Replace EmbeddedAssets::default().load() with direct EmbeddedAssets.load() call in src/web/assets.rs to remove unnecessary default construction.