### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+
+## [0.12.0](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.11.1...schemaui-v0.12.0) - 2026-05-01
+
+
+### Breaking Changes
+
+- **deps:** **BREAKING** remove schemars and h2 dependencies, update indexmap([#125](https://github.com/YuniqueUnic/schemaui/pull/125), @YuniqueUnic)
+
+
+
+
+
+
+### Bug Fixes
+
+- **web:** add configurable title to frontend output message([#127](https://github.com/YuniqueUnic/schemaui/pull/127), @YuniqueUnic)
+
+
+
+
+
+
+### Refactors
+
+- **ui_ast:** add builder tests and refactor module structure([#125](https://github.com/YuniqueUnic/schemaui/pull/125), @YuniqueUnic)
+
+- dependencies and features for web-types support([#125](https://github.com/YuniqueUnic/schemaui/pull/125), @YuniqueUnic)
+
+- **build:** remove unused tokio dependency from schemaui crate([#125](https://github.com/YuniqueUnic/schemaui/pull/125), @YuniqueUnic)
+
+- **cli:** replace eyre with anyhow for error handling([#126](https://github.com/YuniqueUnic/schemaui/pull/126), @YuniqueUnic)
+
+
+
+
+
+
+
+
+### Contributors
+
+- @YuniqueUnic
+
+
 ## [0.11.1](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.11.0...schemaui-v0.11.1) - 2026-04-30
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schemaui"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "schemaui-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["schemaui-cli"]
 [package]
 name = "schemaui"
 authors = ["unic <yuniqueunic@gmail.com>"]
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 keywords = ["tui", "schema", "configuration", "terminal", "cross-platform"]
 categories = ["command-line-interface", "config"]

--- a/README.ZH.md
+++ b/README.ZH.md
@@ -92,7 +92,7 @@ stdin/内联文本，则回退到当前工作目录。对于 JSON 配置，根�
 
 ```toml
 [dependencies]
-schemaui = "0.11.1"
+schemaui = "0.12.0"
 serde_json = "1"
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ References:
 
 ```toml
 [dependencies]
-schemaui = "0.11.1"
+schemaui = "0.12.0"
 serde_json = "1"
 ```
 

--- a/schemaui-cli/CHANGELOG.md
+++ b/schemaui-cli/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [0.7.2](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.7.1...schemaui-cli-v0.7.2) - 2026-05-01
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+### Other
+
+- updated the following local packages: schemaui
+
+
+
+
 ## [0.7.1](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.7.0...schemaui-cli-v0.7.1) - 2026-04-30
 
 

--- a/schemaui-cli/Cargo.toml
+++ b/schemaui-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schemaui-cli"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 authors = ["unic <yuniqueunic@gmail.com>"]
 description = "CLI wrapper for schemaui, rendering JSON Schemas as TUIs"
@@ -25,7 +25,7 @@ name = "schemaui"
 path = "src/main.rs"
 
 [dependencies]
-schemaui = { path = "..", version = "0.11.1", default-features = false }
+schemaui = { path = "..", version = "0.12.0", default-features = false }
 serde_json = "1"
 anyhow = "1"
 clap = { version = "4", default-features = false, features = [


### PR DESCRIPTION



## 🤖 New release

* `schemaui`: 0.11.1 -> 0.12.0 (✓ API compatible changes)
* `schemaui-cli`: 0.7.1 -> 0.7.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `schemaui`

<blockquote>

## [0.12.0](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.11.1...schemaui-v0.12.0) - 2026-05-01

### Breaking Changes

- **deps:** **BREAKING** remove schemars and h2 dependencies, update indexmap([#125](https://github.com/YuniqueUnic/schemaui/pull/125), @YuniqueUnic)






### Bug Fixes

- **web:** add configurable title to frontend output message([#127](https://github.com/YuniqueUnic/schemaui/pull/127), @YuniqueUnic)






### Refactors

- **ui_ast:** add builder tests and refactor module structure([#125](https://github.com/YuniqueUnic/schemaui/pull/125), @YuniqueUnic)

- dependencies and features for web-types support([#125](https://github.com/YuniqueUnic/schemaui/pull/125), @YuniqueUnic)

- **build:** remove unused tokio dependency from schemaui crate([#125](https://github.com/YuniqueUnic/schemaui/pull/125), @YuniqueUnic)

- **cli:** replace eyre with anyhow for error handling([#126](https://github.com/YuniqueUnic/schemaui/pull/126), @YuniqueUnic)








### Contributors

- @YuniqueUnic
</blockquote>

## `schemaui-cli`

<blockquote>

## [0.7.2](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.7.1...schemaui-cli-v0.7.2) - 2026-05-01

### Other

- updated the following local packages: schemaui
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).