### PR TITLE
fix: implement scoped default value application for JSON Schema references

### DIFF
--- a/src/io/input.rs
+++ b/src/io/input.rs
@@ -73,8 +73,12 @@ pub fn schema_from_data_value(value: &Value) -> Value {
 /// Merge user-provided data into an existing schema as `default` values.
 pub fn schema_with_defaults(schema: &Value, defaults: &Value) -> Value {
     let mut enriched = schema.clone();
-    DefaultApplier::new().apply(&mut enriched, defaults);
+    apply_schema_defaults(&mut enriched, defaults);
     enriched
+}
+
+pub(crate) fn apply_schema_defaults(schema: &mut Value, defaults: &Value) {
+    apply_defaults_at(schema, "", defaults);
 }
 
 /// Heuristic used when callers pass a single document and expect SchemaUI to
@@ -123,171 +127,129 @@ pub fn looks_like_json_schema(value: &Value) -> bool {
     false
 }
 
-struct DefaultApplier {
-    active_refs: HashSet<String>,
-}
+fn apply_defaults_at(root: &mut Value, pointer: &str, defaults: &Value) {
+    let Some(schema) = root.pointer_mut(pointer) else {
+        return;
+    };
+    let Some(schema_obj) = schema.as_object_mut() else {
+        return;
+    };
 
-impl DefaultApplier {
-    fn new() -> Self {
-        Self {
-            active_refs: HashSet::new(),
-        }
-    }
+    schema_obj.insert("default".to_string(), defaults.clone());
 
-    fn apply(&mut self, root: &mut Value, defaults: &Value) {
-        self.apply_at(root, "", defaults);
-    }
+    let mut tasks: Vec<(String, Cow<'_, Value>)> = Vec::new();
 
-    fn apply_at(&mut self, root: &mut Value, pointer: &str, defaults: &Value) {
-        let Some(schema) = root.pointer_mut(pointer) else {
-            return;
-        };
-        let Some(schema_obj) = schema.as_object_mut() else {
-            return;
-        };
-
-        schema_obj.insert("default".to_string(), defaults.clone());
-
-        let mut tasks: Vec<(String, Cow<'_, Value>)> = Vec::new();
-
-        if let Some(default_map) = defaults.as_object() {
-            if let Some(properties) = schema_obj.get("properties").and_then(Value::as_object) {
-                for key in properties.keys() {
-                    if let Some(value) = default_map.get(key) {
-                        tasks.push((
-                            child_pointer(pointer, &["properties", key]),
-                            Cow::Borrowed(value),
-                        ));
-                    }
-                }
-            }
-
-            if let Some(patterns) = schema_obj
-                .get("patternProperties")
-                .and_then(Value::as_object)
-            {
-                for (pattern, _) in patterns {
-                    if let Some(matched) = pattern_defaults(pattern, default_map) {
-                        tasks.push((
-                            child_pointer(pointer, &["patternProperties", pattern]),
-                            Cow::Owned(Value::Object(matched)),
-                        ));
-                    }
-                }
-            }
-
-            if let Some(additional_schema) = schema_obj.get("additionalProperties")
-                && additional_schema.is_object()
-            {
-                let excluded: HashSet<&str> = schema_obj
-                    .get("properties")
-                    .and_then(Value::as_object)
-                    .map(|props| props.keys().map(|k| k.as_str()).collect())
-                    .unwrap_or_default();
-                let extras = default_map
-                    .iter()
-                    .filter(|(key, _)| !excluded.contains(key.as_str()))
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect::<Map<_, _>>();
-                if !extras.is_empty() {
+    if let Some(default_map) = defaults.as_object() {
+        if let Some(properties) = schema_obj.get("properties").and_then(Value::as_object) {
+            for key in properties.keys() {
+                if let Some(value) = default_map.get(key) {
                     tasks.push((
-                        child_pointer(pointer, &["additionalProperties"]),
-                        Cow::Owned(Value::Object(extras)),
+                        child_pointer(pointer, &["properties", key]),
+                        Cow::Borrowed(value),
                     ));
                 }
             }
-
-            if let Some(deps) = schema_obj.get("dependencies").and_then(Value::as_object) {
-                for (prop, dep_schema) in deps {
-                    if default_map.contains_key(prop) && dep_schema.is_object() {
-                        tasks.push((
-                            child_pointer(pointer, &["dependencies", prop]),
-                            Cow::Borrowed(defaults),
-                        ));
-                    }
-                }
-            }
-
-            if let Some(deps) = schema_obj
-                .get("dependentSchemas")
-                .and_then(Value::as_object)
-            {
-                for (prop, dep_schema) in deps {
-                    if default_map.contains_key(prop) && dep_schema.is_object() {
-                        tasks.push((
-                            child_pointer(pointer, &["dependentSchemas", prop]),
-                            Cow::Borrowed(defaults),
-                        ));
-                    }
-                }
-            }
         }
 
-        if let Some(default_array) = defaults.as_array()
-            && let Some(items) = schema_obj.get("items")
+        if let Some(patterns) = schema_obj
+            .get("patternProperties")
+            .and_then(Value::as_object)
         {
-            match items {
-                Value::Array(tuple) => {
-                    for (idx, _) in tuple.iter().enumerate() {
-                        if let Some(value) = default_array.get(idx) {
-                            let idx_str = idx.to_string();
-                            tasks.push((
-                                child_pointer(pointer, &["items", &idx_str]),
-                                Cow::Borrowed(value),
-                            ));
-                        }
-                    }
+            for (pattern, _) in patterns {
+                if let Some(matched) = pattern_defaults(pattern, default_map) {
+                    tasks.push((
+                        child_pointer(pointer, &["patternProperties", pattern]),
+                        Cow::Owned(Value::Object(matched)),
+                    ));
                 }
-                Value::Object(_) => {
-                    if let Some(first) = default_array.first() {
-                        tasks.push((child_pointer(pointer, &["items"]), Cow::Borrowed(first)));
-                    }
-                }
-                _ => {}
             }
         }
 
-        for keyword in ["oneOf", "anyOf", "allOf"] {
-            if let Some(Value::Array(branches)) = schema_obj.get(keyword) {
-                for idx in 0..branches.len() {
-                    let idx_str = idx.to_string();
+        if let Some(additional_schema) = schema_obj.get("additionalProperties")
+            && additional_schema.is_object()
+        {
+            let excluded: HashSet<&str> = schema_obj
+                .get("properties")
+                .and_then(Value::as_object)
+                .map(|props| props.keys().map(|k| k.as_str()).collect())
+                .unwrap_or_default();
+            let extras = default_map
+                .iter()
+                .filter(|(key, _)| !excluded.contains(key.as_str()))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect::<Map<_, _>>();
+            if !extras.is_empty() {
+                tasks.push((
+                    child_pointer(pointer, &["additionalProperties"]),
+                    Cow::Owned(Value::Object(extras)),
+                ));
+            }
+        }
+
+        if let Some(deps) = schema_obj.get("dependencies").and_then(Value::as_object) {
+            for (prop, dep_schema) in deps {
+                if default_map.contains_key(prop) && dep_schema.is_object() {
                     tasks.push((
-                        child_pointer(pointer, &[keyword, &idx_str]),
+                        child_pointer(pointer, &["dependencies", prop]),
                         Cow::Borrowed(defaults),
                     ));
                 }
             }
         }
 
-        let mut ref_targets = Vec::new();
-        if let Some(Value::String(reference)) = schema_obj.get("$ref")
-            && let Some(target_pointer) = pointer_from_reference(reference)
-            && self.active_refs.insert(target_pointer.clone())
+        if let Some(deps) = schema_obj
+            .get("dependentSchemas")
+            .and_then(Value::as_object)
         {
-            ref_targets.push(target_pointer.clone());
-            tasks.push((target_pointer, Cow::Borrowed(defaults)));
-        }
-        for (child_pointer, value) in tasks {
-            self.apply_at(root, &child_pointer, value.as_ref());
-        }
-
-        for pointer in ref_targets {
-            self.active_refs.remove(&pointer);
+            for (prop, dep_schema) in deps {
+                if default_map.contains_key(prop) && dep_schema.is_object() {
+                    tasks.push((
+                        child_pointer(pointer, &["dependentSchemas", prop]),
+                        Cow::Borrowed(defaults),
+                    ));
+                }
+            }
         }
     }
-}
 
-fn pointer_from_reference(reference: &str) -> Option<String> {
-    if let Some(path) = reference.strip_prefix('#') {
-        if path.is_empty() {
-            Some(String::new())
-        } else if path.starts_with('/') {
-            Some(path.to_string())
-        } else {
-            Some(format!("/{}", path))
+    if let Some(default_array) = defaults.as_array()
+        && let Some(items) = schema_obj.get("items")
+    {
+        match items {
+            Value::Array(tuple) => {
+                for (idx, _) in tuple.iter().enumerate() {
+                    if let Some(value) = default_array.get(idx) {
+                        let idx_str = idx.to_string();
+                        tasks.push((
+                            child_pointer(pointer, &["items", &idx_str]),
+                            Cow::Borrowed(value),
+                        ));
+                    }
+                }
+            }
+            Value::Object(_) => {
+                if let Some(first) = default_array.first() {
+                    tasks.push((child_pointer(pointer, &["items"]), Cow::Borrowed(first)));
+                }
+            }
+            _ => {}
         }
-    } else {
-        None
+    }
+
+    for keyword in ["oneOf", "anyOf", "allOf"] {
+        if let Some(Value::Array(branches)) = schema_obj.get(keyword) {
+            for idx in 0..branches.len() {
+                let idx_str = idx.to_string();
+                tasks.push((
+                    child_pointer(pointer, &[keyword, &idx_str]),
+                    Cow::Borrowed(defaults),
+                ));
+            }
+        }
+    }
+
+    for (child_pointer, value) in tasks {
+        apply_defaults_at(root, &child_pointer, value.as_ref());
     }
 }
 
@@ -501,37 +463,6 @@ mod tests {
         assert_eq!(
             enriched["items"]["properties"]["tag"]["default"],
             json!("api")
-        );
-    }
-
-    #[test]
-    fn propagates_defaults_through_refs() {
-        let schema = json!({
-            "definitions": {
-                "endpoint": {
-                    "type": "object",
-                    "properties": {
-                        "host": {"type": "string"},
-                        "port": {"type": "integer"}
-                    }
-                }
-            },
-            "type": "object",
-            "properties": {
-                "service": {"$ref": "#/definitions/endpoint"}
-            }
-        });
-        let defaults = json!({
-            "service": {"host": "localhost", "port": 8080}
-        });
-        let enriched = schema_with_defaults(&schema, &defaults);
-        assert_eq!(
-            enriched["properties"]["service"]["default"]["host"],
-            json!("localhost")
-        );
-        assert_eq!(
-            enriched["definitions"]["endpoint"]["properties"]["port"]["default"],
-            json!(8080)
         );
     }
 

--- a/src/schema/resolver.rs
+++ b/src/schema/resolver.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result, bail};
 use percent_encoding::percent_decode_str;
 use serde_json::Value;
 
+use crate::io::input::apply_schema_defaults;
+
 use super::dialect::RootDialectContext;
 use super::model::{Schema, SchemaObject};
 
@@ -21,6 +23,7 @@ impl<'a> SchemaResolver<'a> {
             Schema::Object(object) => {
                 if let Some(reference) = &object.reference {
                     let resolved = self.follow_reference(reference)?;
+                    let resolved = apply_reference_default(resolved, object.as_ref())?;
                     Ok(overlay_reference_annotations(resolved, object.as_ref()))
                 } else {
                     Ok(object.as_ref().clone())
@@ -56,6 +59,26 @@ impl<'a> SchemaResolver<'a> {
 
         bail!("unsupported reference {reference}")
     }
+}
+
+fn apply_reference_default(
+    mut target: SchemaObject,
+    source: &SchemaObject,
+) -> Result<SchemaObject> {
+    let Some(default) = source
+        .metadata
+        .as_deref()
+        .and_then(|metadata| metadata.default.as_ref())
+    else {
+        return Ok(target);
+    };
+
+    let mut value = serde_json::to_value(&target)
+        .context("failed to serialize resolved reference schema for scoped defaults")?;
+    apply_schema_defaults(&mut value, default);
+    target = serde_json::from_value(value)
+        .context("failed to deserialize resolved reference schema with scoped defaults")?;
+    Ok(target)
 }
 
 pub fn schema_reference(schema: &Schema) -> Option<&str> {

--- a/src/tests/schema/mod.rs
+++ b/src/tests/schema/mod.rs
@@ -4,4 +4,5 @@ mod dialect_tests;
 #[cfg(feature = "tui")]
 mod layout_tests;
 mod pipeline_artifact_tests;
+mod ref_default_tests;
 mod resolver_tests;

--- a/src/tests/schema/ref_default_tests.rs
+++ b/src/tests/schema/ref_default_tests.rs
@@ -1,0 +1,183 @@
+use std::path::PathBuf;
+
+use serde_json::{Value, json};
+
+use crate::{
+    io::{DocumentFormat, input::parse_document_str, input::schema_with_defaults},
+    ui_ast::{UiNode, UiNodeKind, build_ui_ast},
+};
+
+fn schema_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("schemas")
+        .join(name)
+}
+
+fn load_schema(name: &str) -> Value {
+    let contents = std::fs::read_to_string(schema_path(name)).expect("schema fixture readable");
+    parse_document_str(&contents, DocumentFormat::Json).expect("schema fixture parses")
+}
+
+fn find_node<'a>(nodes: &'a [UiNode], pointer: &str) -> &'a UiNode {
+    for node in nodes {
+        if node.pointer == pointer {
+            return node;
+        }
+        if let UiNodeKind::Object { children, .. } = &node.kind
+            && let Some(found) = find_node_opt(children, pointer)
+        {
+            return found;
+        }
+    }
+    panic!("node {pointer} not found")
+}
+
+fn find_node_opt<'a>(nodes: &'a [UiNode], pointer: &str) -> Option<&'a UiNode> {
+    nodes.iter().find_map(|node| {
+        if node.pointer == pointer {
+            Some(node)
+        } else if let UiNodeKind::Object { children, .. } = &node.kind {
+            find_node_opt(children, pointer)
+        } else {
+            None
+        }
+    })
+}
+
+fn assert_validates(schema: &Value, instance: &Value) {
+    let validator = jsonschema::validator_for(schema).expect("fixture must compile as jsonschema");
+    assert!(
+        validator.is_valid(instance),
+        "fixture should accept the reproduction instance: {instance}"
+    );
+}
+
+fn assert_ref_defaults_are_scoped(
+    schema: Value,
+    definition_default_pointer: &str,
+    property_without_config_default_pointer: &str,
+) {
+    let defaults = json!({ "second": 40 });
+    assert_validates(&schema, &defaults);
+
+    let enriched = schema_with_defaults(&schema, &defaults);
+
+    assert_eq!(
+        enriched.pointer("/properties/first/default"),
+        None,
+        "config data must not synthesize a default on absent sibling ref properties"
+    );
+    assert_eq!(
+        enriched.pointer("/properties/second/default"),
+        Some(&json!(40)),
+        "config data should remain scoped to the ref property that supplied it"
+    );
+    assert_eq!(
+        enriched.pointer(definition_default_pointer),
+        Some(&json!(20)),
+        "shared definition default must not be overwritten by one ref use-site"
+    );
+
+    let ast = build_ui_ast(&enriched).expect("ui ast builds from enriched schema");
+    assert_eq!(
+        find_node(&ast.roots, "/first").default_value,
+        Some(json!(20)),
+        "absent sibling should use the referenced schema default"
+    );
+    assert_eq!(
+        find_node(&ast.roots, "/second").default_value,
+        Some(json!(40)),
+        "configured sibling should use the instance value"
+    );
+    assert_eq!(
+        find_node(&ast.roots, "/first").default_value,
+        Some(json!(20)),
+        "{property_without_config_default_pointer} must not inherit /second's value"
+    );
+}
+
+#[test]
+fn draft7_dollar_defs_keeps_ref_defaults_scoped() {
+    assert_ref_defaults_are_scoped(
+        load_schema("ref-default-scope.draft7.schema.json"),
+        "/$defs/mydef/default",
+        "/properties/first/default",
+    );
+}
+
+#[test]
+fn draft7_definitions_keeps_ref_defaults_scoped() {
+    assert_ref_defaults_are_scoped(
+        load_schema("ref-default-scope.definitions.draft7.schema.json"),
+        "/definitions/mydef/default",
+        "/properties/first/default",
+    );
+}
+
+#[test]
+fn draft_2020_12_dollar_defs_keeps_ref_defaults_scoped() {
+    assert_ref_defaults_are_scoped(
+        load_schema("ref-default-scope.2020-12.schema.json"),
+        "/$defs/mydef/default",
+        "/properties/first/default",
+    );
+}
+
+#[test]
+fn nested_object_ref_defaults_are_scoped_per_ref_use() {
+    let schema = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "endpoint": {
+                "type": "object",
+                "properties": {
+                    "host": { "type": "string", "default": "localhost" },
+                    "port": { "type": "integer", "default": 80 }
+                },
+                "additionalProperties": false
+            }
+        },
+        "type": "object",
+        "properties": {
+            "primary": { "$ref": "#/$defs/endpoint" },
+            "secondary": { "$ref": "#/$defs/endpoint" }
+        },
+        "additionalProperties": false
+    });
+    let defaults = json!({
+        "secondary": { "host": "api.internal", "port": 8080 }
+    });
+
+    assert_validates(&schema, &defaults);
+
+    let enriched = schema_with_defaults(&schema, &defaults);
+    assert_eq!(
+        enriched.pointer("/$defs/endpoint/properties/host/default"),
+        Some(&json!("localhost")),
+        "nested object definition must keep its original host default"
+    );
+    assert_eq!(
+        enriched.pointer("/$defs/endpoint/properties/port/default"),
+        Some(&json!(80)),
+        "nested object definition must keep its original port default"
+    );
+
+    let ast = build_ui_ast(&enriched).expect("ui ast builds");
+    assert_eq!(
+        find_node(&ast.roots, "/primary/host").default_value,
+        Some(json!("localhost"))
+    );
+    assert_eq!(
+        find_node(&ast.roots, "/primary/port").default_value,
+        Some(json!(80))
+    );
+    assert_eq!(
+        find_node(&ast.roots, "/secondary/host").default_value,
+        Some(json!("api.internal"))
+    );
+    assert_eq!(
+        find_node(&ast.roots, "/secondary/port").default_value,
+        Some(json!(8080))
+    );
+}

--- a/tests/schemas/ref-default-scope.2020-12.schema.json
+++ b/tests/schemas/ref-default-scope.2020-12.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "mydef": {
+      "type": "integer",
+      "default": 20
+    }
+  },
+  "type": "object",
+  "properties": {
+    "first": {
+      "$ref": "#/$defs/mydef"
+    },
+    "second": {
+      "$ref": "#/$defs/mydef"
+    }
+  },
+  "required": [],
+  "additionalProperties": false
+}

--- a/tests/schemas/ref-default-scope.definitions.draft7.schema.json
+++ b/tests/schemas/ref-default-scope.definitions.draft7.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "mydef": {
+      "type": "integer",
+      "default": 20
+    }
+  },
+  "type": "object",
+  "properties": {
+    "first": {
+      "$ref": "#/definitions/mydef"
+    },
+    "second": {
+      "$ref": "#/definitions/mydef"
+    }
+  },
+  "propertyNames": true,
+  "required": [],
+  "additionalProperties": false
+}

--- a/tests/schemas/ref-default-scope.draft7.schema.json
+++ b/tests/schemas/ref-default-scope.draft7.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$defs": {
+    "mydef": {
+      "type": "integer",
+      "default": 20
+    }
+  },
+  "type": "object",
+  "properties": {
+    "first": {
+      "$ref": "#/$defs/mydef"
+    },
+    "second": {
+      "$ref": "#/$defs/mydef"
+    }
+  },
+  "propertyNames": true,
+  "required": [],
+  "additionalProperties": false
+}


### PR DESCRIPTION
- Replace DefaultApplier struct with functional approach using apply_schema_defaults function that properly handles reference scoping
- Add apply_reference_default function to apply defaults at reference resolution time while maintaining proper isolation between different reference uses of the same schema definition
- Create comprehensive test suite for reference default scoping across various JSON Schema versions (draft-07, draft-2020-12) and property types including nested objects
- Add test fixtures covering $defs, definitions, and complex nested reference scenarios to ensure defaults remain scoped per reference use-site rather than modifying shared definitions

This change ensures that when multiple properties reference the same schema definition with different default values, each reference use maintains its own scoped defaults without affecting other references to the same underlying definition.

close #138 