### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+
+## [0.12.2](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.12.1...schemaui-v0.12.2) - 2026-05-21
+
+
+
+
+
+
+### Bug Fixes
+
+- implement scoped default value application for JSON Schema references([#139](https://github.com/YuniqueUnic/schemaui/pull/139), @YuniqueUnic)
+
+
+
+
+
+
+
+
+
+
+
+
+### Contributors
+
+- @YuniqueUnic
+
+
 ## [0.12.1](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.12.0...schemaui-v0.12.1) - 2026-05-13
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "email_address"
@@ -889,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc59d2432e047d6090ba1d83c782d0128bd6203857978218f5614dbd3287281f"
+checksum = "6a5fe5206f06e589caf25e79fc05ccdf91fca745685fe9fe1a13bbdfb479a631"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1340,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb674900ca31acd75c4aaf63f48e43e719631c0539ea5a9e64163d1296bcb730"
+checksum = "69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -1469,7 +1469,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schemaui"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "schemaui-cli"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2243,9 +2243,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["schemaui-cli"]
 [package]
 name = "schemaui"
 authors = ["unic <yuniqueunic@gmail.com>"]
-version = "0.12.1"
+version = "0.12.2"
 edition = "2024"
 keywords = ["tui", "schema", "configuration", "terminal", "cross-platform"]
 categories = ["command-line-interface", "config"]

--- a/README.ZH.md
+++ b/README.ZH.md
@@ -92,7 +92,7 @@ stdin/内联文本，则回退到当前工作目录。对于 JSON 配置，根�
 
 ```toml
 [dependencies]
-schemaui = "0.12.1"
+schemaui = "0.12.2"
 serde_json = "1"
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ References:
 
 ```toml
 [dependencies]
-schemaui = "0.12.1"
+schemaui = "0.12.2"
 serde_json = "1"
 ```
 

--- a/schemaui-cli/CHANGELOG.md
+++ b/schemaui-cli/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [0.7.4](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.7.3...schemaui-cli-v0.7.4) - 2026-05-21
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+### Other
+
+- updated the following local packages: schemaui
+
+
+
+
 ## [0.7.3](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.7.2...schemaui-cli-v0.7.3) - 2026-05-13
 
 

--- a/schemaui-cli/Cargo.toml
+++ b/schemaui-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schemaui-cli"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 authors = ["unic <yuniqueunic@gmail.com>"]
 description = "CLI wrapper for schemaui, rendering JSON Schemas as TUIs"
@@ -25,7 +25,7 @@ name = "schemaui"
 path = "src/main.rs"
 
 [dependencies]
-schemaui = { path = "..", version = "0.12.1", default-features = false }
+schemaui = { path = "..", version = "0.12.2", default-features = false }
 serde_json = "1"
 anyhow = "1"
 clap = { version = "4", default-features = false, features = [


### PR DESCRIPTION



## 🤖 New release

* `schemaui`: 0.12.1 -> 0.12.2 (✓ API compatible changes)
* `schemaui-cli`: 0.7.3 -> 0.7.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `schemaui`

<blockquote>

## [0.12.2](https://github.com/YuniqueUnic/schemaui/compare/schemaui-v0.12.1...schemaui-v0.12.2) - 2026-05-21

### Bug Fixes

- implement scoped default value application for JSON Schema references([#139](https://github.com/YuniqueUnic/schemaui/pull/139), @YuniqueUnic)












### Contributors

- @YuniqueUnic
</blockquote>

## `schemaui-cli`

<blockquote>

## [0.7.4](https://github.com/YuniqueUnic/schemaui/compare/schemaui-cli-v0.7.3...schemaui-cli-v0.7.4) - 2026-05-21

### Other

- updated the following local packages: schemaui
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).